### PR TITLE
Modification to allow building from command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = OpenToonz
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
This PR is in reference to issue #32.

This commit allows users to run "make html" from the command line
instead of from the Anaconda prompt. As a result, installing Anaconda is
no longer required to test local changes to the documentation.

Sorry, this is the second time doing this. The first time I accidentally included the commits from another branch.