### PR TITLE
Corrected an instance of sub-Xsheet

### DIFF
--- a/source/production_workflow.rst
+++ b/source/production_workflow.rst
@@ -140,7 +140,7 @@ See  :ref:`Drawing Animation Levels <drawing_animation_levels>`  and  :ref:`Crea
 
 Layout
 ~~~~~~
-In the layout phase, all of the elements that are necessary for the scene (backgrounds, props, characters, reference animations) are loaded from the library in Xsheet, usually as sub-Xsheets. They are put in place according to the animatic. Basic animation is achieved by setting key positions for animated characters or importing reference animations.
+In the layout phase, all of the elements that are necessary for the scene (backgrounds, props, characters, reference animations) are loaded from the library in Xsheet, usually as Sub-Xsheets. They are put in place according to the animatic. Basic animation is achieved by setting key positions for animated characters or importing reference animations.
 
 Camera movements and animation timing previously set in the animatic are refined. 
 


### PR DESCRIPTION
I was reading Production Workflow and noticed a "sub-Xsheet" that I
somehow missed in my earlier edits. It is now "Sub-Xsheet".