### PR TITLE
arrow replacement

### DIFF
--- a/source/applying_special_fx.rst
+++ b/source/applying_special_fx.rst
@@ -143,7 +143,7 @@ For example in case of a Matte In effect, the column to be matted has to be link
 
     Do one of the following:
 
-    - Choose Xsheet > **New FX**.
+    - Choose Xsheet  →  **New FX**.
 
     - Click the **New FX** button (|fx|) in the bottom bar of the FX Schematic window.
 
@@ -236,7 +236,7 @@ When pasting a copied/cut selection, several options are available:
 
     Select the links you want to delete and do one of the following:
 
-    - Choose Edit > **Delete**.
+    - Choose Edit  →  **Delete**.
 
     - Right-click any selected link and choose **Delete** from the menu that opens.
 
@@ -337,7 +337,7 @@ When more than one Output node is defined, you can set which is the active one (
 
     Do one of the following:
 
-    - Select it and choose Edit > **Delete**.
+    - Select it and choose Edit  →  **Delete**.
 
     - Right-click it and choose **Delete** from the menu that opens.
 

--- a/source/cleaning-up_scanned_drawings.rst
+++ b/source/cleaning-up_scanned_drawings.rst
@@ -7,7 +7,7 @@ In order to be painted and edited with OpenToonz, scanned drawings have to under
 The process generates a Toonz raster level (TLV format) and the related default palette (TPL format), where the styles used to paint the level will be stored.
 
 
-.. note:: If the computer performance slows down during the cleanup process of very high resolution images, try activating the Minimize Raster Memory Fragmentation* option in the Files > Preferences > General dialog (see  :ref:`Optimizing the Memory Usage <optimizing_the_memory_usage>`  ).
+.. note:: If the computer performance slows down during the cleanup process of very high resolution images, try activating the Minimize Raster Memory Fragmentation* option in the Files  →  Preferences  →  General dialog (see  :ref:`Optimizing the Memory Usage <optimizing_the_memory_usage>`  ).
 
 .. _the_cleanup_settings:
 
@@ -21,7 +21,7 @@ Usually settings are defined and checked for one of the level drawings, then app
 
 .. tip:: **To define cleanup settings:**
 
-    Choose Scan & Cleanup > Cleanup Settings and use the dialog to control the cleanup process parameters and options. 
+    Choose Scan & Cleanup  →  Cleanup Settings and use the dialog to control the cleanup process parameters and options. 
 
 .. _defining_cleanup_parameters:
 
@@ -58,7 +58,7 @@ Autocenter parameters are the following:
 
     3. Set the Field Guide to be used as reference to set the center in the correct place, and to match the shape of the pegbar holes.
 
-    4. Choose Scan & Cleanup > Preview Cleanup to preview the process in the Viewer.
+    4. Choose Scan & Cleanup  →  Preview Cleanup to preview the process in the Viewer.
 
 .. _other_cleanup_parameters:
 
@@ -124,7 +124,7 @@ Parameters are the following:
 
 .. tip:: **To set the line processing for black and white or greyscale lineart drawings:**
 
-    1. Activate the Line Processing > Greyscale option.
+    1. Activate the Line Processing  →  Greyscale option.
 
     2. Define the parameters according to your needs.
 
@@ -151,7 +151,7 @@ Three different autoadjust algorithms are available:
 
 .. note:: The advantage of the Histo-L mode over the others is that it adjusts the grey levels of each image independently, while the other algorithms equalize each image to make it look like the first one of the level.
 
-Only the effects of the Black Eq process can be checked using the Scan & Cleanup > Cleanup Preview command; the effects of Histogram and Histo-L are only visible selecting a sequence of at least two frames (i.e. one as reference frame and the others to be auto-adjusted) and processing them using the Scan & Cleanup > Cleanup command. You may need to make a few trials using different algorithms before obtaining the desired results. 
+Only the effects of the Black Eq process can be checked using the Scan & Cleanup  →  Cleanup Preview command; the effects of Histogram and Histo-L are only visible selecting a sequence of at least two frames (i.e. one as reference frame and the others to be auto-adjusted) and processing them using the Scan & Cleanup  →  Cleanup command. You may need to make a few trials using different algorithms before obtaining the desired results. 
 
 .. note:: These algorithms work on the area of the drawing specified in the Field text boxes, excluding a 5 mm boundary edge. In this way any line might be drawn to delimit the camera shot on paper, and the pegbar holes, do not affect the result.
 
@@ -208,7 +208,7 @@ In the color list, parameters for the other colors are the following:
 
 .. tip:: **To set the line processing for colored lineart drawings:**
 
-    1. Activate the Line Processing > Color option.
+    1. Activate the Line Processing  →  Color option.
 
     2. Define the general parameters according to your needs.
 
@@ -363,11 +363,11 @@ If you change any parameter in the cleanup settings, the preview automatically u
 
 .. tip:: **To activate the cleanup preview in the main viewer:**
 
-    In the Xsheet select the scanned drawing you want to preview, and choose Scan & Cleanup > Preview Cleanup. 
+    In the Xsheet select the scanned drawing you want to preview, and choose Scan & Cleanup  →  Preview Cleanup. 
 
 .. tip:: **To deactivate the cleanup preview in the main viewer:**
 
-    Choose Scan & Cleanup > Preview Cleanup. 
+    Choose Scan & Cleanup  →  Preview Cleanup. 
 
 .. tip:: **To preview a different drawing:**
 
@@ -375,7 +375,7 @@ If you change any parameter in the cleanup settings, the preview automatically u
 
 .. tip:: **To exit the preview cleanup mode:**
 
-    Choose Scan & Cleanup > Preview Cleanup to deactivate it. 
+    Choose Scan & Cleanup  →  Preview Cleanup to deactivate it. 
 
 
 .. _using_the_opacity_check:
@@ -410,11 +410,11 @@ If you change any of the Cleanup or Camera parameters, the camera test automatic
 
 .. tip:: **To activate the camera test:**
 
-    In the Xsheet select the drawing you want to preview, and choose Scan & Cleanup > Camera Test. 
+    In the Xsheet select the drawing you want to preview, and choose Scan & Cleanup  →  Camera Test. 
 
 .. tip:: **To deactivate the camera test:**
 
-    Choose Scan & Cleanup > Camera Test. 
+    Choose Scan & Cleanup  →  Camera Test. 
 
 .. tip:: **To modify the cleanup camera directly in the viewer:**
 
@@ -434,7 +434,7 @@ If you change any of the Cleanup or Camera parameters, the camera test automatic
 
 .. tip:: **To exit the camera test mode:**
 
-    Choose Scan & Cleanup > Camera Test to deactivate it. 
+    Choose Scan & Cleanup  →  Camera Test to deactivate it. 
 
 
 .. _cleaning_up_drawings:
@@ -455,7 +455,7 @@ It is also possible to automatically create a backup copy of the cleaned up draw
 
 .. tip:: **To automatically create a backup copy of the cleaned up drawings:**
 
-    1. Choose File > Preferences > Drawing.
+    1. Choose File  →  Preferences  →  Drawing.
 
     2. Activate the Keep Original Cleaned Up Drawings As Backup option.
 
@@ -465,7 +465,7 @@ It is also possible to automatically create a backup copy of the cleaned up draw
 
     2. Do one of the following:
 
-    - Choose Level > Revert to Cleaned Up.
+    - Choose Level  →  Revert to Cleaned Up.
 
     - Right click the selection and choose Revert to Cleaned Up from the menu that opens.
 
@@ -492,7 +492,7 @@ If you want you can also revert to the scanned version of the level you cleaned 
 
     1. In the Xsheet select the drawings you want to process.
 
-    2. Choose Scan & Cleanup > Cleanup.
+    2. Choose Scan & Cleanup  →  Cleanup.
 
     3. In the Cleanup dialog for each drawing choose one of the following:
 
@@ -508,7 +508,7 @@ If you want you can also revert to the scanned version of the level you cleaned 
 
     1. Select any drawing of the cleaned up level.
 
-    2. Choose Level > Level Setting.
+    2. Choose Level  →  Level Setting.
 
     3. Copy the Scan Path information in the Path text field.
 

--- a/source/creating_movements.rst
+++ b/source/creating_movements.rst
@@ -204,7 +204,7 @@ Columns/layers and pegbars are always linked, at least to the table: this means 
 
 .. tip:: **To remove selected links:**
 
-    Choose Edit > **Delete**, links will be replaced by default ones (i.e to the table).
+    Choose Edit  →  **Delete**, links will be replaced by default ones (i.e to the table).
 
 
 .. _advanced_linking:
@@ -327,7 +327,7 @@ Hook information is saved along with each level, as a file in XML format, named 
 
 .. tip:: **To delete a hook:**
 
-    Select the related hook in any frame and choose Edit > **Delete**.
+    Select the related hook in any frame and choose Edit  →  **Delete**.
 
 .. tip:: **To link an object to a level hook:**
 
@@ -402,7 +402,7 @@ Once areas to be tracked are defined in the first frame of a range, it's possibl
 
     1. Choose the **Tracker** tool (|tracker|) and select the region you want to delete.
 
-    2. Choose Edit > **Delete**.
+    2. Choose Edit  →  **Delete**.
 
 .. tip:: **To track a defined region in a series of images:**
 
@@ -412,7 +412,7 @@ Once areas to be tracked are defined in the first frame of a range, it's possibl
 
     3. Select the frame range in the Xsheet/Timeline or in the Level Strip.
 
-    4. Choose Level > **Tracking**, set the tracking options and click the **Track** button.
+    4. Choose Level  →  **Tracking**, set the tracking options and click the **Track** button.
 
 .. tip:: **To link an object to the tracked region:**
 
@@ -463,7 +463,7 @@ In the **Animate tool** (|animate|) options bar you can set the following:
 
 .. note:: If the tool options bar is too short to display all the tool options, it can be scrolled by using arrow buttons available at its ends.
 
-.. note:: Position values are expressed in the default unit of measure set in the Preferences > Interface dialog (see  :ref:`Choosing the Working Unit <choosing_the_working_unit>`  ).
+.. note:: Position values are expressed in the default unit of measure set in the Preferences  →  Interface dialog (see  :ref:`Choosing the Working Unit <choosing_the_working_unit>`  ).
 
 
 .. _animate_tool_handle:
@@ -681,7 +681,7 @@ It's also possible to link the key positions of the objects to the positions of 
 
     1. Select the link between the object and the motion path. 
 
-    2. Choose Edit > **Delete**.
+    2. Choose Edit  →  **Delete**.
 
 .. tip:: **To set the type of movement along a motion path:**
 
@@ -737,7 +737,7 @@ It's also possible to link the key positions of the objects to the positions of 
 
     Do one of the following:
 
-    - Select the motion path node and choose Edit > **Delete**.
+    - Select the motion path node and choose Edit  →  **Delete**.
 
     - Right-click the motion path node and choose **Delete** from the menu that opens.
 
@@ -851,7 +851,7 @@ When a multiple key is deleted at the current frame, any key available in any Xs
 
     2. Select the frame where you want to insert keys.
 
-    3. Choose Xsheet > **Insert Multiple Keys**.
+    3. Choose Xsheet  →  **Insert Multiple Keys**.
 
 .. tip:: **To remove several keys at once:**
 
@@ -863,7 +863,7 @@ When a multiple key is deleted at the current frame, any key available in any Xs
 
     2. Select the frame where you want to delete keys.
 
-    3. Choose Xsheet > **Remove Multiple Keys**.
+    3. Choose Xsheet  →  **Remove Multiple Keys**.
 
 
 .. _working_in_a_3d_environment:

--- a/source/drawing_animation_levels.rst
+++ b/source/drawing_animation_levels.rst
@@ -31,11 +31,11 @@ By default Toonz Vector and Toonz Raster levels are saved in the **+drawing** fo
 
 .. tip:: **To define the Default Type of Level to Draw:**
 
-    1. Open File > Preferences > Drawing.
+    1. Open File  →  Preferences  →  Drawing.
 
     2. Choose the level type you want to use as default from the **Default Level Type:** option menu. **Width**, **Height** and **DPI** fields are available for **Toonz Raster Level** and **Raster Level** options.
 
-.. note:: The Width, Height and DPI values set in the File > Preferences > Drawing section will also be used as default for the **New Level** dialog.
+.. note:: The Width, Height and DPI values set in the File  →  Preferences  →  Drawing section will also be used as default for the **New Level** dialog.
 
 
 Drawing Animation Levels
@@ -61,13 +61,13 @@ Settings like the length of the level and the numbering order can be edited late
 
 When a new level is created in an empty column, the color of that column header and the cells where the new level gets exposed are colored denoting the type of level: **light yellow** for Toonz Vector levels, **light green** for Toonz Raster levels, and **light blue** for Raster levels (see  :ref:`Working with Xsheet Columns <working_with_xsheet_columns>`  ). 
 
-.. note:: The New Level dialog inherits the **Default Level Type** settings defined in Preferences > Drawing.
+.. note:: The New Level dialog inherits the **Default Level Type** settings defined in Preferences  →  Drawing.
 
 .. tip:: **To create a new animation level to draw:**
 
     1. Do one of the following:
 
-    - Select a cell in the Xsheet/Timeline where you want to place your animation level and choose File > **New Level...**
+    - Select a cell in the Xsheet/Timeline where you want to place your animation level and choose File  →  **New Level...**
 
     - Right-click the cell in the Xsheet/Timeline where you want to place your animation level and choose **New Level...** from the menu that opens.
 
@@ -90,16 +90,16 @@ When a new level is created in an empty column, the color of that column header 
 
 Using the Autocreation Option
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When in Preferences > Drawing the **Autocreation:** option is set to **Enabled**, it is possible to create new drawings automatically by using drawing tools in the viewer. If the currently selected cell is empty, a new level will be automatically created and named with the first available letter of the alphabet; if the currently selected cell is the one **right after** one containing a level drawing (either in the Xsheet/Timeline or the Level Strip) a new drawing will be added to that level.
+When in Preferences  →  Drawing the **Autocreation:** option is set to **Enabled**, it is possible to create new drawings automatically by using drawing tools in the viewer. If the currently selected cell is empty, a new level will be automatically created and named with the first available letter of the alphabet; if the currently selected cell is the one **right after** one containing a level drawing (either in the Xsheet/Timeline or the Level Strip) a new drawing will be added to that level.
 
-.. note:: The level type will be the one defined in Preferences > Drawing as **Default Level Type**.
+.. note:: The level type will be the one defined in Preferences  →  Drawing as **Default Level Type**.
 
 
 .. _using_the_xsheet_as_animation_sheet:
 
 Using the Xsheet as Animation Sheet
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When in Preferences > Drawing the **Autocreation:** option is set to **Use the Xsheet as Animation Sheet**, it's possible to create new drawings automatically by using drawing tools in the viewer. If the currently selected cell is empty and belongs to an empty column, a new level will be automatically created and named with the first available letter of the alphabet; if the currently selected cell is **anywhere after** one containing a level drawing, a new drawing will be added to that level. In both cases the drawings will take its number from the scene current frame ; if that drawing number already existed in the level, a letter will be added to its number (e.g. A.0001a.ext). 
+When in Preferences  →  Drawing the **Autocreation:** option is set to **Use the Xsheet as Animation Sheet**, it's possible to create new drawings automatically by using drawing tools in the viewer. If the currently selected cell is empty and belongs to an empty column, a new level will be automatically created and named with the first available letter of the alphabet; if the currently selected cell is **anywhere after** one containing a level drawing, a new drawing will be added to that level. In both cases the drawings will take its number from the scene current frame ; if that drawing number already existed in the level, a letter will be added to its number (e.g. A.0001a.ext). 
 
 This working method allows you to work as a traditional animator: you can start creating the *key drawings*, and then add *breakdown drawings*, and then *inbetween drawings*. You can quickly check your animation flipping it in the viewer.
 
@@ -109,7 +109,7 @@ It's also possible to create a new drawing in a cell that contains a *hold*: the
 
 Once the animation is completed you can renumber the whole sequence according to the Xsheet/Timeline frame numbering.
 
-.. note:: The level type will be the one defined in Preferences > Drawing as **Default Level Type**.
+.. note:: The level type will be the one defined in Preferences  →  Drawing as **Default Level Type**.
 
 .. tip:: **To create a new animation level**
 
@@ -123,7 +123,7 @@ Once the animation is completed you can renumber the whole sequence according to
 
     1. Select the cells with the drawings you want to renumber.
 
-    2. Choose the Cells > **Autorenumber** command.
+    2. Choose the Cells  →  **Autorenumber** command.
 
      .. note:: The **Autorenumber** command is also available in the menu that opens when right-clicking in a cell.
 
@@ -217,7 +217,7 @@ Raster drawings and images that usually are displayed in the viewer according to
 
 .. tip:: **To activate or deactivate the raster visualization for vector drawings:**
 
-    Activate or deactivate the View > **Visualize Vector As Raster** option.
+    Activate or deactivate the View  →  **Visualize Vector As Raster** option.
 
 .. tip:: **To display raster drawings and images at their actual pixel size:**
 
@@ -232,13 +232,13 @@ Raster drawings and images that usually are displayed in the viewer according to
 
 Customizing the Viewer
 ~~~~~~~~~~~~~~~~~~~~~~
-The viewer can be customized according to your needs: the background colors visible in the viewer and inside the camera box can be changed; a field guide and a safe area can be displayed for reference; the table and camera box can be hidden; custom guides can be added to help you in aligning objects or composing the elements of the scene for a particular frame. The View > **Inks Only** check allows to hide the painted areas of the levels facilitating the drawing process.
+The viewer can be customized according to your needs: the background colors visible in the viewer and inside the camera box can be changed; a field guide and a safe area can be displayed for reference; the table and camera box can be hidden; custom guides can be added to help you in aligning objects or composing the elements of the scene for a particular frame. The View  →  **Inks Only** check allows to hide the painted areas of the levels facilitating the drawing process.
 
 The set of buttons and information available in the bottom bar of the viewer can be customized as well, so that only the elements you require are visible.
 
 .. tip:: **To change the viewer background color:**
 
-    1. Open the File > Preferences > **Colors** dialog.
+    1. Open the File  →  Preferences  →  **Colors** dialog.
 
     2. Define the **Viewer BG Color** by doing one of the following:
 
@@ -248,7 +248,7 @@ The set of buttons and information available in the bottom bar of the viewer can
 
 .. tip:: **To change the camera box background color:**
 
-    1. Open the Xsheet > **Scene Settings...** dialog.
+    1. Open the Xsheet  →  **Scene Settings...** dialog.
 
     2. Define the **Camera BG Color** by doing one of the following:
 
@@ -258,31 +258,31 @@ The set of buttons and information available in the bottom bar of the viewer can
 
 .. tip:: **To show or hide the table:**
 
-    Choose View > **Table** to show or hide the table.
+    Choose View  →  **Table** to show or hide the table.
 
 .. tip:: **To show or hide the camera box:**
 
-    Choose View > **Camera Box** to show or hide the camera box.
+    Choose View  →  **Camera Box** to show or hide the camera box.
 
     .. note:: The camera box visualization also triggers the safe area visualization (see below).
 
 .. tip:: **To show or hide the camera background color:**
 
-    Choose View > **Camera BG Color** to show or hide the camera box background color.
+    Choose View  →  **Camera BG Color** to show or hide the camera box background color.
 
 .. tip:: **To show or hide the field guide:**
 
-    Choose View > **Field Guide** to show or hide the field guide.
+    Choose View  →  **Field Guide** to show or hide the field guide.
 
 .. tip:: **To define the displayed field guide:**
 
-    1. Open the Xsheet > **Scene Settings...** dialog.
+    1. Open the Xsheet  →  **Scene Settings...** dialog.
 
     2. Define the **Field Guide Size:** and **A/R:**. **Size** is the number of width fields of the field guide (1 field is equal to 1 inch), and the **A/R** is the ratio between the field guide width and height.
 
 .. tip:: **To show or hide the safe area:**
 
-    Choose View > **Safe Area** to show or hide the safe area.
+    Choose View  →  **Safe Area** to show or hide the safe area.
 
     .. note:: The safe area is not visible if the camera box is hidden (see above).
 
@@ -300,11 +300,11 @@ The set of buttons and information available in the bottom bar of the viewer can
 
 .. tip:: **To show or hide guides:**
 
-    Choose View > **Guides** to show or hide the guides.
+    Choose View  →  **Guides** to show or hide the guides.
 
 .. tip:: **To show or hide rulers where guide markers are located:**
 
-    Choose View > **Rulers** to show or hide the rulers.
+    Choose View  →  **Rulers** to show or hide the rulers.
 
   .. note:: When the viewer work area is rotated, guides are rotated as well, but rulers and guide markers preserve their position and orientation. However the position of a guide can still be controlled by markers, even if visually they don’t match anymore.
 
@@ -591,7 +591,7 @@ When a conversion is performed, a new level is created according to the selectio
 
     1. Select the level frames to convert in the Xsheet/Timeline.
 
-    2. Choose Level > **Convert to Vectors...**
+    2. Choose Level  →  **Convert to Vectors...**
 
     3. In the dialog set parameters for the conversion.
 
@@ -682,7 +682,7 @@ The new size can be set in any unit supported by OpenToonz, by using absolute or
 
     1. Select the Toonz Raster or Raster level you want to modify in the Xsheet/Timeline.
 
-    2. Choose Level > **Canvas Size...**, the Canvas Size dialog opens.
+    2. Choose Level  →  **Canvas Size...**, the Canvas Size dialog opens.
 
     3. In the dialog set the **Unit** to express the new size of the canvas, and set the **Width** and **Height** of the new canvas; activate the **Relative** option to define the new size by specifying only the size the canvas has to increase or decrease.
 
@@ -756,7 +756,7 @@ In the tool options bar you can set the following:
 
 - **Modify Savebox** check box allows you to resize the *Savebox* of a drawing. The drawing part that, because of the editing, falls outside of the savebox will be erased. This is available for Toonz Raster drawings only.
 
-  .. note:: The *Savebox* size can be set automatically to the minimum size by activating the Preferences > Drawing > **Minimize Savebox after Editing** option.
+  .. note:: The *Savebox* size can be set automatically to the minimum size by activating the Preferences  →  Drawing  →  **Minimize Savebox after Editing** option.
 
 - **No Antialiasing** when activated, the antialiasing is not applied when the selection is deformed or rotated. This is available on Toonz Raster and Raster drawings only.
 
@@ -946,7 +946,7 @@ As the **Selection** tool (|selection|) considers the group as a whole, if you w
 
     2. Do one of the following:
 
-    - Choose Edit > **Group**.
+    - Choose Edit  →  **Group**.
 
     - Right-click on the selection and choose **Group** from the menu that opens.
 
@@ -956,7 +956,7 @@ As the **Selection** tool (|selection|) considers the group as a whole, if you w
 
     2. Do one of the following:
 
-    - Choose Edit > **Ungroup**.
+    - Choose Edit  →  **Ungroup**.
 
     - Right-click on the selection and choose **Ungroup** from the menu that opens.
 
@@ -964,7 +964,7 @@ As the **Selection** tool (|selection|) considers the group as a whole, if you w
 
     Do one of the following:
 
-    - Select the group, then choose Edit > **Enter Group**.
+    - Select the group, then choose Edit  →  **Enter Group**.
 
     - Right-click the group and choose **Enter Group** from the menu that opens.
 
@@ -974,7 +974,7 @@ As the **Selection** tool (|selection|) considers the group as a whole, if you w
 
     Do one of the following:
 
-    - Choose Edit > **Exit Group**.
+    - Choose Edit  →  **Exit Group**.
 
     - Right-click the group and choose **Exit Group** from the menu that opens.
 
@@ -1015,7 +1015,7 @@ For each vector drawing, strokes and groups sorting order can be changed by sett
 
     Do one of the following:
 
-    - Choose Edit > **Bring to Front**.
+    - Choose Edit  →  **Bring to Front**.
 
     - Right-click on the selection and choose **Bring to Front** from the menu that opens.
 
@@ -1023,7 +1023,7 @@ For each vector drawing, strokes and groups sorting order can be changed by sett
 
     Do one of the following:
 
-    - Choose Edit > **Bring Forward**.
+    - Choose Edit  →  **Bring Forward**.
 
     - Right-click on the selection and choose **Bring Forward** from the menu that opens.
 
@@ -1031,7 +1031,7 @@ For each vector drawing, strokes and groups sorting order can be changed by sett
 
     Do one of the following:
 
-    - Choose Edit > **Send Back**.
+    - Choose Edit  →  **Send Back**.
 
     - Right-click on the selection and choose **Send Back** from the menu that opens.
 
@@ -1039,7 +1039,7 @@ For each vector drawing, strokes and groups sorting order can be changed by sett
 
     Do one of the following:
 
-    - Choose Edit > **Send Backward**.
+    - Choose Edit  →  **Send Backward**.
 
     - Right-click on the selection and choose **Send Backward** from the menu that opens.
 
@@ -1115,7 +1115,7 @@ The option Auto Select Drawing is available to automatically select any vector o
 
 .. tip:: **To delete the selection:**
 
-    Choose Edit > Delete.
+    Choose Edit  →  Delete.
 
 .. tip:: **To turn a control point into a corner point:**
 
@@ -1287,7 +1287,7 @@ The best solution for this kind of issue is to overlap the final section of stro
 
     2. Do one of the following:
 
-    - Choose Edit > **Remove Vector Overflow**.
+    - Choose Edit  →  **Remove Vector Overflow**.
 
     - Right-click the selection and choose **Remove Vector Overflow** from the menu that opens.
 
@@ -1309,7 +1309,7 @@ Instead of animating a level by starting every time from a blank frame, you can 
 
 The sequence of the animation level drawings can be easily controlled in the Level Strip.
 
-You can use both the Edit > **Duplicate Drawing** command and the standard **Copy** and **Paste** commands to make a copy of a drawing that you can later modify to create slight movements.
+You can use both the Edit  →  **Duplicate Drawing** command and the standard **Copy** and **Paste** commands to make a copy of a drawing that you can later modify to create slight movements.
 
 When you use the **Duplicate Drawing** command, the selected drawing is duplicated in the following frame. If the following frame already contains a drawing, it's shifted down in order to insert the duplicated drawing in the sequence.
 
@@ -1325,9 +1325,9 @@ Once finished, you can make a copy of the modified drawing, and modify it in its
 
     3. Copy the selected drawing in the following frame by doing one of the following:
 
-    - Choose Cells > **Duplicate Drawing**.
+    - Choose Cells  →  **Duplicate Drawing**.
 
-    - Choose Edit > **Copy**, then select the following frame and choose **Paste**.
+    - Choose Edit  →  **Copy**, then select the following frame and choose **Paste**.
 
     4. Select the new drawing in the Level Strip.
 
@@ -1368,7 +1368,7 @@ If you want the interpolation to happen slower or faster, you can insert frames,
 
     1. Select the level where you want to perform interpolation.
 
-    2. In the Level Strip select the frame range, from the drawing you want to interpolate from, to the one you want to interpolate to. If you want the interpolation to last more frames, make room for more drawings with the Edit > **Insert** command.
+    2. In the Level Strip select the frame range, from the drawing you want to interpolate from, to the one you want to interpolate to. If you want the interpolation to last more frames, make room for more drawings with the Edit  →  **Insert** command.
 
     3. Click the vertical strip labeled **INBETWEEN** displayed on the right of the frame range selection.
 
@@ -1436,7 +1436,7 @@ The cell selection can also spread over several columns: in this case the same n
 
     2. Do one of the following:
 
-    - Choose Cells > **Clone**.
+    - Choose Cells  →  **Clone**.
 
     - Right-click in the selection and choose **Clone** from the menu that opens.
 
@@ -1503,7 +1503,7 @@ The way images are displayed in Onion Skin mode can be customized in the Prefere
 
 .. tip:: **To customize the way images are displayed in onion skin mode:**
 
-    1. Choose File > Preferences > **Onion Skin**.
+    1. Choose File  →  Preferences  →  **Onion Skin**.
 
     2. Do any of the following:
 
@@ -1530,13 +1530,13 @@ To better check the new drawing and the animation, you can toggle the Shift and 
 
     1. Position the frame cursor on the frame where you want to draw the inbetween drawing.
 
-    2. Enable View > **Shift and Trace**; the previous and next drawings will be visualized.
+    2. Enable View  →  **Shift and Trace**; the previous and next drawings will be visualized.
 
 .. tip:: **To Edit the Position of the reference drawings:**
 
     1. Position the frame cursor where you want to draw the inbetween drawing and sketch the path of action line beteween your reference points.
 
-    2. Activate View > **Edit Shift**.
+    2. Activate View  →  **Edit Shift**.
 
     3. Click on the drawing you want to reposition; the related bounding box will be displayed.
 
@@ -1554,7 +1554,7 @@ To better check the new drawing and the animation, you can toggle the Shift and 
 
     1. Position the frame cursor where you want to draw the inbetween drawing and sketch the path of action line beteween your reference points.
 
-    2. Activate View > **Edit Shift**.
+    2. Activate View  →  **Edit Shift**.
 
     3. Ctrl-click and drag to create a path, from the reference point in the first drawing, to the reference point in the second one. The starting and the ending points will be overlapped at the center of the path.
 
@@ -1566,11 +1566,11 @@ To better check the new drawing and the animation, you can toggle the Shift and 
 
 .. tip:: **To Toggle the Shift and Trace visualization:**
 
-    Activate View > **No Shift** to toggle the visualization of the reference drawings back to their original position.
+    Activate View  →  **No Shift** to toggle the visualization of the reference drawings back to their original position.
 
 .. tip:: **To Reset the position of the reference drawings:**
 
-    Choose the View > **Reset Shift** command.
+    Choose the View  →  **Reset Shift** command.
 
 .. tip:: **To Create an inbetween drawing using the Shift and Trace feature:**
 
@@ -1580,11 +1580,11 @@ To better check the new drawing and the animation, you can toggle the Shift and 
 
     3. Select the cell where you want to create the inbetween drawing.
 
-    4. Activate View > **Shift and Trace**.
+    4. Activate View  →  **Shift and Trace**.
 
     5. Sketch the path of action line beteween your reference points.
 
-    6. Activate View > **Edit Shift** and edit the position of the reference drawings.
+    6. Activate View  →  **Edit Shift** and edit the position of the reference drawings.
 
     7. Create the inbetween drawing.
 

--- a/source/editing_animation_levels.rst
+++ b/source/editing_animation_levels.rst
@@ -21,7 +21,7 @@ When one or more frames are selected you can perform standard cut, copy, paste, 
 
 When you change the order of the drawings in the Level Strip, or when a drawing is cut, deleted or inserted, and drawings are exposed in the scene, the Xsheet/Timeline will continue to contain a reference to that particular frame of the animation level, whatever its content is. When the Xsheet/Timeline contains a reference to a drawing that is eliminated in the Level Strip, the level name and number turn red, to warn you that there is no drawing available for that cell anymore.
 
-The width of the level strip pane cannot be resized freely, because it depends on the size of the animation level preview icons, but it can be customized in the Preferences > Interface dialog.
+The width of the level strip pane cannot be resized freely, because it depends on the size of the animation level preview icons, but it can be customized in the Preferences  →  Interface dialog.
 
 .. tip:: **To edit an animation level in the Level Strip:**
 
@@ -59,9 +59,9 @@ The width of the level strip pane cannot be resized freely, because it depends o
 
     - Ctrl-click (PC) or Cmd-click (Mac) the frames to add them to, or remove them from the selection.
 
-    - Use the Edit > Select All command to select all of the level drawings.
+    - Use the Edit  →  Select All command to select all of the level drawings.
 
-    - Use the Edit > Invert Selection command to invert the current selection of drawings.
+    - Use the Edit  →  Invert Selection command to invert the current selection of drawings.
 
 .. note:: The Select All and Invert Selection commands are also available in the menu that opens when right-clicking in the Level Strip.
 
@@ -71,7 +71,7 @@ The width of the level strip pane cannot be resized freely, because it depends o
 
 .. tip:: **To customize the level strip width:**
 
-    1. Choose File > Preferences > Interface.
+    1. Choose File  →  Preferences  →  Interface.
 
     2. Set the Width and Height values of the level strip Icon Size*.
 
@@ -145,19 +145,19 @@ If you need to add a range of frames to a level, for instance for scanning them 
 
 Both the renumbering and the adding frames operation fails if the numbering assigned to the frames is used by already existing frames.
 
-.. note:: If the Automatically Create Drawings option is activated in the Preferences > Drawing dialog, when you want to add a drawing at the end of the sequence simply select the first grey frame available, and draw in the Viewer. 
+.. note:: If the Automatically Create Drawings option is activated in the Preferences  →  Drawing dialog, when you want to add a drawing at the end of the sequence simply select the first grey frame available, and draw in the Viewer. 
 
 .. tip:: **To renumber drawings of an animation level:**
 
     1. Select the drawings you want to renumber; also a non-continuous selection is allowed.
 
-    2. Select Level > Renumber.
+    2. Select Level  →  Renumber.
 
     3. In the dialog that opens set the Start Frame number that will be assigned to the first drawing of the selection, and the Step used to number all following frames in the selection.
 
 .. tip:: **To add drawings to an animation level:**
 
-    1. Select Level > Add Frames.
+    1. Select Level  →  Add Frames.
 
     2. In the dialog that opens sets the frame range you want to add, and the Step used to number the frames in the range.
 
@@ -172,7 +172,7 @@ In case some mistakes are made during the editing of a level, or during the pain
 
 For Toonz raster levels generated from a cleanup process, it is also possible to retrieve the original cleaned up drawings.
 
-.. note:: In order to revert to the original cleaned up drawings the Preferences > Drawing > Keep Original Cleaned Up Drawings As Backup option has to be activated when the cleanup is performed (see  :ref:`Cleaning up Drawings <cleaning_up_drawings>`  ).
+.. note:: In order to revert to the original cleaned up drawings the Preferences  →  Drawing  →  Keep Original Cleaned Up Drawings As Backup option has to be activated when the cleanup is performed (see  :ref:`Cleaning up Drawings <cleaning_up_drawings>`  ).
 
 .. tip:: **To revert the level drawings to the last saved version:**
 
@@ -180,7 +180,7 @@ For Toonz raster levels generated from a cleanup process, it is also possible to
 
     2. Do one of the following:
 
-    - Choose Level > Revert to Last Saved Version.
+    - Choose Level  →  Revert to Last Saved Version.
 
     - Right click the selection and choose Revert to Last Saved Version from the menu that opens.
 
@@ -190,7 +190,7 @@ For Toonz raster levels generated from a cleanup process, it is also possible to
 
     2. Do one of the following:
 
-    - Choose Level > Revert to Cleaned Up.
+    - Choose Level  →  Revert to Cleaned Up.
 
     - Right click the selection and choose Revert to Cleaned Up from the menu that opens.
 
@@ -199,7 +199,7 @@ For Toonz raster levels generated from a cleanup process, it is also possible to
 
 Merging Animation Levels
 ------------------------
-Toonz vector levels and standard raster levels can be easily merged into a single animation level generated by flattening them according to their stacking order, using the  > Merge Levels command. TLV levels can be merged, using the  > Merge TLV Levels command.
+Toonz vector levels and standard raster levels can be easily merged into a single animation level generated by flattening them according to their stacking order, using the   →  Merge Levels command. TLV levels can be merged, using the   →  Merge TLV Levels command.
 
 This can be useful for instance if you are sketching an animation with drawings repeated in several cells and exposed in several columns, and you want to generate a single sequence of drawings.
 
@@ -210,7 +210,7 @@ In both cases there is no limit to the number of columns you can merge.
 
 Merging Toonz Vector Levels or Raster Levels
 ''''''''''''''''''''''''''''''''''''''''''''
-Using the  > Merge Levels command the number of resulting drawings will depend on the number of drawings exposed in the first column on the left of the selection. When merging raster levels, the resolution of the resulting drawings will depend on the resolution of the drawings exposed in the first column on the left of the selection.
+Using the   →  Merge Levels command the number of resulting drawings will depend on the number of drawings exposed in the first column on the left of the selection. When merging raster levels, the resolution of the resulting drawings will depend on the resolution of the drawings exposed in the first column on the left of the selection.
 
 Animation levels are merged according to the following guidelines:
 
@@ -230,15 +230,15 @@ For Toonz vector levels each drawing of the merged levels will be retained as a 
 
     1. Select the columns where the animation levels you want to merge are exposed.
 
-    2. Choose  > Merge Levels.
+    2. Choose   →  Merge Levels.
 
 .. _merging_toonz_raster_levels:
 
 Merging Toonz Raster Levels
 '''''''''''''''''''''''''''
-The  > Merge tlv Levels allows to combine several columns containing Toonz Raster Levels creating a new TLV level. The merged columns will be eliminated from the  and replaced with a new TLV level.
+The   →  Merge tlv Levels allows to combine several columns containing Toonz Raster Levels creating a new TLV level. The merged columns will be eliminated from the  and replaced with a new TLV level.
 
-Using the  > Merge tlv Levels command the number of resulting drawings will depend on the frames combination of the involved levels. When merging Toonz Raster levels, the resolution of the resulting level will depend on the resolution of the drawings exposed in the first column on the left of the selection.
+Using the   →  Merge tlv Levels command the number of resulting drawings will depend on the frames combination of the involved levels. When merging Toonz Raster levels, the resolution of the resulting level will depend on the resolution of the drawings exposed in the first column on the left of the selection.
 
 Animation levels are merged according to the following guidelines:
 
@@ -256,7 +256,7 @@ When levels are merged, any geometrical transformation achieved by editing and m
 
     1. Select two ore more columns filled with the tlv you want to merge.
 
-    2. Choose  > Merge tlv Levels
+    2. Choose   →  Merge tlv Levels
 
     3. Define File name and location in the pop up that opens and press Apply.
 
@@ -300,7 +300,7 @@ In case it is needed to adjust drawings in order to increase the darkness and th
 
     1. Select the images or the level frames to process in the .
 
-    2. Choose Level > Brightness and Contrast.
+    2. Choose Level  →  Brightness and Contrast.
 
     3. In the dialog that opens set the brightness and contrast variation.
 
@@ -316,7 +316,7 @@ Allows to add antialias or to make it smoother or harder on raster and Toonz ras
 
     1. Select the images or the level frames to process in the .
 
-    2. Choose Level > Add Antialias...
+    2. Choose Level  →  Add Antialias...
 
     3. In the dialog that opens set the threshold and the smoothness values.
 
@@ -332,7 +332,7 @@ Adjusts the highlights and shadows of the Source content by remapping pixels int
 
     1. Select the images or the level frames to adjust in the .
 
-    2. Choose Level > Adjust Levels.
+    2. Choose Level  →  Adjust Levels.
 
     3. Adjust the image levels
 
@@ -348,7 +348,7 @@ The Adjust Thickness command allows to modify the thickness of all the lines of 
 
     1. Select the images or the level frames to adjust in the .
 
-    2. Choose Level > Adjust Thickness.
+    2. Choose Level  →  Adjust Thickness.
 
     3. Choose a mode. The modes are: Scale Thickness that scale lines up or down using a percentage value, Add Thickness that add an amount of thickness to the lines using the current unit, Costant Thickness that apply a thickness value, ignoring its variations, using the current unit.
 
@@ -366,7 +366,7 @@ In case it is needed to adjust the drawing colors it is possible to fade the dra
 
     1. Select the images or the level frames to fade in the .
 
-    2. Choose Level > Color Fade.
+    2. Choose Level  →  Color Fade.
 
     3. In the dialog that opens set the color you want to fade the selection to by doing one of the following:
 
@@ -394,7 +394,7 @@ The preview is available to check the result. The alpha toggle allows to produce
 
     1. Select the images or the level frames to process in the .
 
-    2. Choose Level > Binarize.
+    2. Choose Level  →  Binarize.
 
     3. Activate the Preview toggle to check the result.
 
@@ -408,7 +408,7 @@ Saving Levels
 -------------
 All the editing performed in the level strip is not saved until you save the level. You can also automatically save all of the editing done on any level of the  by saving the scene (see  :ref:`Saving and Loading Scenes <saving_and_loading_scenes>`  ). 
 
-When saving an animation level it is possible to automatically create a backup file of the previous version by setting the Backup Animation Levels when Saving option in the Preferences > General dialog. The backup version is created in the same location where the level is saved, and has an _backup suffix.
+When saving an animation level it is possible to automatically create a backup file of the previous version by setting the Backup Animation Levels when Saving option in the Preferences  →  General dialog. The backup version is created in the same location where the level is saved, and has an _backup suffix.
 
 .. note:: An asterisk after the level name in the level strip title bar denotes that there are unsaved changes for the current level.
 
@@ -416,13 +416,13 @@ When saving an animation level it is possible to automatically create a backup f
 
     Do one of the following:
 
-    - Choose File > Save Level.
+    - Choose File  →  Save Level.
 
     - Right-click in the scene cast and choose Save Level from the menu that opens.
 
 .. tip:: **To save the current level with a different name in a different location:**
 
-    1. Choose File > Save Level As.
+    1. Choose File  →  Save Level As.
 
     2. In the browser that opens select for the level you want to save a location and name, and click the Save button.
 
@@ -446,7 +446,7 @@ The No Antialias option allow to remove the antialias from the exported sequence
 
 .. tip:: **To export the current level:**
 
-    1. Choose File > Export Level.
+    1. Choose File  →  Export Level.
 
     2. In the File Browser page select the level you want to save, a location and a name.
 
@@ -472,7 +472,7 @@ The No Antialias option allow to remove the antialias from the exported sequence
 
 .. tip:: **To set the file format options:**
 
-    1. Choose File > Output Settings.
+    1. Choose File  →  Output Settings.
 
     2. Set the options for the format you want to use for exporting levels.
 

--- a/source/editing_curves_and_numerical_columns.rst
+++ b/source/editing_curves_and_numerical_columns.rst
@@ -67,19 +67,19 @@ Transformation data can be saved and loaded as a CURVE file, to allow the export
 
 .. tip:: **To open the Graph Editor in a separate window:**
 
-    1. Make sure the option **Graph Editor Opens in Popup** is selected from the **Function Editor:** dropdown menu, in the Preferences > Interface window. (Restart OpenToonz).
+    1. Make sure the option **Graph Editor Opens in Popup** is selected from the **Function Editor:** dropdown menu, in the Preferences  →  Interface window. (Restart OpenToonz).
     
     2. Click the **Function Editor Toggle** button (|schematic|) in the top bar of the Function Editor.
 
 .. tip:: **To open the Spreadsheet in a separate window:**
 
-    1. Make sure the option **Spreadsheet Opens in Popup** is selected from the **Function Editor:** dropdown menu, in the Preferences > Interface window. (Restart OpenToonz).
+    1. Make sure the option **Spreadsheet Opens in Popup** is selected from the **Function Editor:** dropdown menu, in the Preferences  →  Interface window. (Restart OpenToonz).
     
     2. Click the **Function Editor Toggle** button (|schematic|) in the top bar of the Function Editor.
 
 .. tip:: **To switch between Spreadsheet and Graph Editor in the Function Editor:**
 
-    1. Make sure the option **Toggle Between Graph Editor and Spreadsheet** is selected from the **Function Editor:** dropdown menu, in the Preferences > Interface window. (Restart OpenToonz).
+    1. Make sure the option **Toggle Between Graph Editor and Spreadsheet** is selected from the **Function Editor:** dropdown menu, in the Preferences  →  Interface window. (Restart OpenToonz).
     
     2. Click the **Function Editor Toggle** button (|schematic|) in the top bar of the Function Editor.
 
@@ -239,7 +239,7 @@ Frames and keyframes can be navigated by using the related buttons in the top ba
 
     Do one of the following:
 
-    - Select the keyframe to remove and choose Edit > **Delete**.
+    - Select the keyframe to remove and choose Edit  →  **Delete**.
 
     - Set the current frame where a keyframe is and click the **Set Key** button (|key|).
 
@@ -296,9 +296,9 @@ Setting Segment Interpolations
 ------------------------------
 A transformation segment, that is to say the section between two keyframes, can have different interpolations affecting the way the value changes from one key to another. The set interpolation will be displayed graphically in the Graph Editor, and as a series of values, one for each frame, in the Spreadsheet.
 
-Available interpolations are the following: **Linear**, **Speed In / Speed Out**, **Ease In / Ease Out**, **Ease In / Ease Out %**, **Exponential**, **Expression**, **File**, **Constant** and **Similar Shape**. The *default interpolation* can be set in the Preferences > Animation window, but the interpolation can be changed at any time in the interpolation area of the Function Editor, on the top right of the window.
+Available interpolations are the following: **Linear**, **Speed In / Speed Out**, **Ease In / Ease Out**, **Ease In / Ease Out %**, **Exponential**, **Expression**, **File**, **Constant** and **Similar Shape**. The *default interpolation* can be set in the Preferences  →  Animation window, but the interpolation can be changed at any time in the interpolation area of the Function Editor, on the top right of the window.
 
-In the same area it is also possible to define an interpolation **Step**, that is to say the number of frames for which the interpolation values have to be repeated, for instance to match a movement with an animation level exposed at a specific step. The default animation step can be set in the Preferences > Animation window.
+In the same area it is also possible to define an interpolation **Step**, that is to say the number of frames for which the interpolation values have to be repeated, for instance to match a movement with an animation level exposed at a specific step. The default animation step can be set in the Preferences  →  Animation window.
 
 .. tip:: **To set the type of interpolation for a segment in the Spreadsheet:**
 

--- a/source/interface_overview.rst
+++ b/source/interface_overview.rst
@@ -42,7 +42,7 @@ Rooms can be named and their order can be rearranged. New rooms can be added and
 
 .. tip:: **To return to the set of rooms provided with Toonz:**
 
-    Choose Windows > Reset to Default Rooms.
+    Choose Windows  →  Reset to Default Rooms.
 
 
 .. _customizing_rooms:
@@ -94,7 +94,7 @@ Most of the panes can be maximized to fill the full interface, and can be added 
 
 .. tip:: **To lock/unlock the rooms configuration:**
 
-    Activate/deactivate the Windows > Lock Room Panes option.
+    Activate/deactivate the Windows  →  Lock Room Panes option.
 
 
 .. _room_panes:
@@ -441,11 +441,11 @@ The Command Bar pane can be docked in any part of the OpenToonz UI.
 
 .. tip:: **To display the Command Bar:**
 
-    - Choose Windows > Command Bar.
+    - Choose Windows  →  Command Bar.
 
 .. tip:: **To customize the Command Bar buttons:**
 
-    1. Choose Windows > Command Bar to open the Command Bar.
+    1. Choose Windows  →  Command Bar to open the Command Bar.
 
     2. Right click on it and select **Customize Command Bar** from the menu that opens. The Customize Command Bar window will open.
 
@@ -572,7 +572,7 @@ The QSS file can be edited with any text editor software, e.g. Notepad or TextEd
 
 .. tip:: **To choose the interface language:**
 
-    1. Choose File > Preferences > Interface.
+    1. Choose File  →  Preferences  →  Interface.
 
     2. In the Language* option menu choose the language you want to use in the interface.
 
@@ -580,7 +580,7 @@ The QSS file can be edited with any text editor software, e.g. Notepad or TextEd
 
 .. tip:: **To choose the interface theme:**
 
-    1. Choose File > Preferences > Interface.
+    1. Choose File  →  Preferences  →  Interface.
 
     2. In the Theme option menu choose the style to be applied to the interface.
 

--- a/source/keyboard_shortcuts.rst
+++ b/source/keyboard_shortcuts.rst
@@ -17,7 +17,7 @@ Shortcuts are specific to each user, meaning that each user in the system can ha
 
 .. tip:: **To configure a shortcut:**
 
-    1. Choose ``File > Configure Shortcuts...``
+    1. Choose ``File  →  Configure Shortcuts...``
 
     2. Search for the command or tool you want to configure the shortcut for in the appropriate folder, or by using the Search field at the top of the window.
 
@@ -27,7 +27,7 @@ Shortcuts are specific to each user, meaning that each user in the system can ha
 
 .. tip:: **To remove a configured shortcut:**
 
-    1. Choose ``File > Configure Shortcuts...``
+    1. Choose ``File  →  Configure Shortcuts...``
 
     2. Search for the command or tool you want to configure the shortcut for in the appropriate folder, or by using the Search field at the top of the window.
 

--- a/source/managing_palettes_and_styles.rst
+++ b/source/managing_palettes_and_styles.rst
@@ -374,7 +374,7 @@ Only the first style in the palette, labeled **Color_0**, cannot be edited: inst
 
     Do one of the following:
 
-    - Choose Windows > **Style Editor**.
+    - Choose Windows  →  **Style Editor**.
 
     - Double-click the style you want to edit in the Palette Editor.
 

--- a/source/managing_projects.rst
+++ b/source/managing_projects.rst
@@ -95,7 +95,7 @@ If you want a new scene to be part of a new project, first you have to define a 
 
 .. tip:: **To create a new project:**
 
-    1. Choose File > New Project. 
+    1. Choose File  →  New Project. 
 
     2. Select the projectroot or repository (see  :ref:`Configuring the Version Control in OpenToonz <configuring_the_version_control_in_toonz>`  ), and the project or folder where you want to create the new project.
 
@@ -111,11 +111,11 @@ If you want a new scene to be part of a new project, first you have to define a 
 
     1. Set the project as the current one.
 
-    2. Choose File > New Scene.
+    2. Choose File  →  New Scene.
 
 .. tip:: **To change project default folders:**
 
-    Select File > Project Settings and change default folders paths.
+    Select File  →  Project Settings and change default folders paths.
 
 .. note:: When changing default folders, scenes previously created in the same project may fail retrieving used files.
 

--- a/source/painting_animation_levels.rst
+++ b/source/painting_animation_levels.rst
@@ -8,7 +8,7 @@ All Toonz level drawings are made of **lines** (determined by the strokes of sca
 
 .. note:: All the painting work is not saved until you save the related level, or use the **Save All** command (see  :ref:`Saving Levels <saving_levels>`  ).
 
-.. note:: If the computer performance worsens during the painting process of Toonz Raster animation levels, try activating the **Minimize Raster Memory Fragmentation** option in the Preferences > General dialog (see  :ref:`Optimizing the Memory Usage <optimizing_the_memory_usage>`  ).
+.. note:: If the computer performance worsens during the painting process of Toonz Raster animation levels, try activating the **Minimize Raster Memory Fragmentation** option in the Preferences  →  General dialog (see  :ref:`Optimizing the Memory Usage <optimizing_the_memory_usage>`  ).
 
 
 .. _painting_tools:
@@ -54,7 +54,7 @@ Areas can be filled when their outline is well-defined, with no gaps occurring a
 
 Options available for the painting tools can help you to speed up the painting job. You can decide which options are the most suitable for your task by following the guidelines below.
 
-.. note:: In Toonz Raster levels, the areas that can be painted are limited either by the image border or by the image Savebox, according to the **Use the TLV Savebox to Limit Filling Operations** option available in Preferences > Tools.
+.. note:: In Toonz Raster levels, the areas that can be painted are limited either by the image border or by the image Savebox, according to the **Use the TLV Savebox to Limit Filling Operations** option available in Preferences  →  Tools.
 
 .. note:: Some styles may not be suitable for filling areas, such as the **Trail** or **Vector** styles or some of the **Generated** styles. If you select one of these styles in the Palette, and you use it to fill an area, no operation will be performed.
 
@@ -229,7 +229,7 @@ Checking Painted Drawings
 '''''''''''''''''''''''''
 To control if all the drawings areas are properly painted, and to see if the filling left small gaps along the lines antialiasing, or where a certain style is being used to paint lines or areas, it is possible to activate a series of checks:
 
-- The **Transparency Check** displays all the painted areas in the color defined in Preferences > Colors > Paint Color, all the lines or vector strokes in the color defined in Preferences > Colors > Ink Color on White Bg (or Preferences > Colors > Ink Color on Black Bg, depending on the chosen background color).
+- The **Transparency Check** displays all the painted areas in the color defined in Preferences  →  Colors  →  Paint Color, all the lines or vector strokes in the color defined in Preferences  →  Colors  →  Ink Color on White Bg (or Preferences  →  Colors  →  Ink Color on Black Bg, depending on the chosen background color).
 
 - The **Ink Check** displays the *lines or vector strokes*, colored with the current style in red.
 
@@ -388,7 +388,7 @@ Applied match lines can be deleted as a whole from the destination level, or it 
 
     4. Select the two columns by shift-clicking or click-draging their headers.
 
-    5. Choose Xsheet > **Apply Match Lines...**
+    5. Choose Xsheet  →  **Apply Match Lines...**
 
     6. In the dialog that opens choose the styles to be used for the match lines and the line prevalence, and click the Apply button.
 
@@ -396,13 +396,13 @@ Applied match lines can be deleted as a whole from the destination level, or it 
 
     1. Select the columns/layers, the cells, or the Level Strip frames where the animation level with the applied match lines is.
 
-    2. Choose Xsheet > **Delete Match Lines**.
+    2. Choose Xsheet  →  **Delete Match Lines**.
 
 .. tip:: **To delete lines by selecting the style index:**
 
     1. Select the columns/layers, the cells, or the Level Strip frames where the animation level whose lines you want to delete is.
 
-    2. Choose Xsheet > **Delete Lines...**
+    2. Choose Xsheet  →  **Delete Lines...**
 
     3. In the dialog that opens choose the indexes of the styles used for lines you want to delete, and the frames where you want to apply the deletion.
 
@@ -462,7 +462,7 @@ When the image is displayed in the Color Model viewer, you can use it not only a
 
     1. Do one of the following:
 
-    - Choose File > **Load Color Model...**, and load the Toonz level or the full color raster image you want to use as a reference.
+    - Choose File  →  **Load Color Model...**, and load the Toonz level or the full color raster image you want to use as a reference.
 
     - **Right-click** in the Color Model viewer and choose **Load Color Model** from the menu that opens.
 
@@ -524,7 +524,7 @@ When the image is displayed in the Color Model viewer, you can use it not only a
 
     1. In the Studio Palette select the palette to which you want to associate a color model, and do one of the following:
 
-    - Choose File > **Load Color Model...**.
+    - Choose File  →  **Load Color Model...**.
 
     - Right-click the palette in the studio palette tree and choose **Load Color Model...** from the menu that opens (see  :ref:`Using the Studio Palette <using_the_studio_palette>`  for details).
 

--- a/source/rendering_the_animation.rst
+++ b/source/rendering_the_animation.rst
@@ -15,7 +15,7 @@ Animations can be previewed directly in the OpenToonz Viewer, including in the *
 
 In both cases the Flipbook window tools can be used, and its appearance can be customized (see  :ref:`Using the Flipbook <using_the_flipbook>`  ). 
 
-.. note:: If the computer performance worsens during the preview process of raster animation levels, try activating the **Minimize Raster Memory Fragmentation** option in the Preferences > General dialog (see  :ref:`Optimizing the Memory Usage <optimizing_the_memory_usage>`  ).
+.. note:: If the computer performance worsens during the preview process of raster animation levels, try activating the **Minimize Raster Memory Fragmentation** option in the Preferences  →  General dialog (see  :ref:`Optimizing the Memory Usage <optimizing_the_memory_usage>`  ).
 
 
 .. _previewing_frames_in_the_viewer:
@@ -87,9 +87,9 @@ The animation can be previewed in a separate window according to specific *Previ
 
 It is possible to define the range of previewed frames both in the Preview Settings and by using the Playback Markers in the Xsheet/Timeline: any change made in one mode is reflected in the other one as well (see  :ref:`Using the Playback Markers <using_the_playback_markers>`  ). It is also possible to display blank frames after each preview playback, when looping.
 
-It is possible to activate the Preferences > Preview > **Fit to Flipbook** option to ensure that the previewed images fit the size of the preview window, regardless their resolution.
+It is possible to activate the Preferences  →  Preview  →  **Fit to Flipbook** option to ensure that the previewed images fit the size of the preview window, regardless their resolution.
 
-It is possible to clone the Preview window, or to automatically open as many Preview windows as needed by activating the Preferences > Preview > **Display in a New Flipbook Window** option, for example to examine or compare specific frames by using the Flipbook tools (see  :ref:`Using the Flipbook <using_the_flipbook>` ). 
+It is possible to clone the Preview window, or to automatically open as many Preview windows as needed by activating the Preferences  →  Preview  →  **Display in a New Flipbook Window** option, for example to examine or compare specific frames by using the Flipbook tools (see  :ref:`Using the Flipbook <using_the_flipbook>` ). 
 
  |preview_settings_dialog| 
 
@@ -127,13 +127,13 @@ Additionally, *OpenToonz* provides several other standard resampling filters tha
 
 .. tip:: **To set the scene preview settings:**
 
-    1. Choose File > **Preview Settings**.
+    1. Choose File  →  **Preview Settings**.
 
     2. Set the options you want to use for the preview.
 
 .. tip:: **To open the preview window:**
 
-    Choose File > **Preview**.
+    Choose File  →  **Preview**.
 
 .. tip:: **To clone the preview window:**
 
@@ -145,19 +145,19 @@ Additionally, *OpenToonz* provides several other standard resampling filters tha
 
 .. tip:: **To open a new Flipbook window every time you run a preview:**
 
-    1. In File > Preferences > Preview.
+    1. In File  →  Preferences  →  Preview.
 
     2. Activate the **Display in a New Flipbook Window** option.
 
 .. tip:: **To rewind the preview content automatically after playback:**
 
-    1. In File > Preferences > Preview.
+    1. In File  →  Preferences  →  Preview.
 
     2. Activate the **Rewind After Playback** option.
 
 .. tip:: **To display blank frames after each preview playback when looping:**
 
-    1. In File > Preferences > Preview.
+    1. In File  →  Preferences  →  Preview.
 
     2. Do any of the following:
 
@@ -232,7 +232,7 @@ The colors displayed as background in the flipbook can also be customized so tha
 
 .. tip:: **To open a Flipbook:**
 
-    Choose Window > **Flipbook**.
+    Choose Window  →  **Flipbook**.
 
 .. tip:: **To load some contents into a Flipbook:**
 
@@ -282,7 +282,7 @@ The colors displayed as background in the flipbook can also be customized so tha
 
 .. tip:: **To rewind the Flipbook content automatically after playback:**
 
-    1. In File > Preferences > Preview.
+    1. In File  →  Preferences  →  Preview.
 
     2. Activate the **Rewind after Playback** option.
 
@@ -298,7 +298,7 @@ The colors displayed as background in the flipbook can also be customized so tha
 
 .. tip:: **To link the playback of all the open Flipbook windows:**
 
-    Choose View > **Link Flipbooks** to activate or deactivate the linked playback mode.
+    Choose View  →  **Link Flipbooks** to activate or deactivate the linked playback mode.
 
 .. tip:: **To set the playback frame rate:**
 
@@ -366,7 +366,7 @@ The colors displayed as background in the flipbook can also be customized so tha
 
 .. tip:: **To define the previewed images background color:**
 
-    1. Choose Xsheet > **Scene Settings...**
+    1. Choose Xsheet  →  **Scene Settings...**
 
     2. Set the **Camera BG Color** by doing one of the following:
 
@@ -378,7 +378,7 @@ The colors displayed as background in the flipbook can also be customized so tha
 
 .. tip:: **To define the Flipbook checkerboard colors:**
 
-    1. Choose Xsheet > **Scene Settings...**
+    1. Choose Xsheet  →  **Scene Settings...**
 
     2. Set the **Checkerboard Color 1** and **Color 2** by doing one of the following:
 
@@ -437,7 +437,7 @@ Rendering the Animation
 -----------------------
 Final animations can be rendered directly by loading the related scene, or in batch mode. In both cases the rendering properties are defined in the Output Settings dialog.
 
-.. note:: Information about the scene name and frame number can be included when needed in rendered frames by activating the Show Info in Rendered Frames option in the Preferences > General dialog.
+.. note:: Information about the scene name and frame number can be included when needed in rendered frames by activating the Show Info in Rendered Frames option in the Preferences  →  General dialog.
 
 
 .. _choosing_the_output_settings:
@@ -455,7 +455,7 @@ Camera Settings
 
 - **Output Camera:** sets which camera, among the ones defined in the scene, has to be used to render the animation. 
 
-- **Frame Size** sets the frame size of the current camera, also available in the Xsheet > **Camera Settings...** dialog (see  :ref:`Defining Camera Settings <defining_camera_settings>`  ).
+- **Frame Size** sets the frame size of the current camera, also available in the Xsheet  →  **Camera Settings...** dialog (see  :ref:`Defining Camera Settings <defining_camera_settings>`  ).
 
 - **Frame Start:** and **End:** set the frame range of the scene to render; by default these values refer to the whole scene length.
 
@@ -515,7 +515,7 @@ Other Settings
 
   Field rendering is only relevant for scenes that are intended for video output. Options are **None** (for rendering *progresive* frames), **Even (PAL)** and **Odd (NTSC)** (for chosing which of the rendered *interlaced* fields is to be shown in first place). Usually you should choose it according to the video standard you are outputting to. 
 
-- **Frame Rate**: is the frame rate of the scene, also available in the Xsheet > **Scene Settings...** dialog (see  :ref:`Setting the Frame Rate <setting_the_frame_rate>`  ).
+- **Frame Rate**: is the frame rate of the scene, also available in the Xsheet  →  **Scene Settings...** dialog (see  :ref:`Setting the Frame Rate <setting_the_frame_rate>`  ).
 
 - **Stretch from FPS:  To:** changes the timing of the Xsheet when outputting files; in this way you can output a number of frames that is independent from the frame rate set in the scene settings.
 
@@ -539,7 +539,7 @@ Other Settings
 
 .. tip:: **To set the scene output settings:**
 
-    1. Choose File > Output Settings.
+    1. Choose File  →  Output Settings.
 
     2. Set the options you want to use for the final rendering.
 
@@ -561,13 +561,13 @@ Each item has an information **Type:**. Most of them will automatically retrieve
 Other types, such as **Text** or **Image** allow to input user defined data to be displayed in the Clapperboard.
 
 The settings can be saved as a *Preset* in order to be reused later, using the **Save as Preset** and **Load Preset** buttons.
-They can also be stored in the project's default settings by using the File > **Save Default Settings** command.
+They can also be stored in the project's default settings by using the File  →  **Save Default Settings** command.
 
 .. note:: WARNING: Adding the Clapperboard will make the scene file to lose compatibility with older versions of OpenToonz. Setting the **Duration:** back to 0 will remove the clapperboard data from the scene, so that compatibility can be restored.
 
 .. tip:: **To Add a Clapperboard:**
 
-    1. Open the File > Output Settings... dialog.
+    1. Open the File  →  Output Settings... dialog.
     
     2. Select the output file format to any movie type (3GP, AVI, MOV, MP4 or WebM).
     
@@ -583,13 +583,13 @@ They can also be stored in the project's default settings by using the File > **
 
 .. tip:: **To temporarily deactivate the Clapperboard:**
 
-    1. Open the File > Output Settings... dialog.
+    1. Open the File  →  Output Settings... dialog.
     
     2. Disable the **Add Clapperboard** option.
     
 .. tip:: **To Delete the Clapperboard:**
 
-    1. Open the File > Output Settings... dialog.
+    1. Open the File  →  Output Settings... dialog.
     
     2. Open **Other Settings** group box.
     
@@ -612,7 +612,7 @@ With **Multiple Rendering:** it's possible to render automatically, from a singl
 
 The names of the different output files are automatically generated in order to avoid any name conflict between file names. In particular they are built by appending to the *output file name*: the **column name**, then the **column ID** (as can be read in the node tooltip), then the **effect name**, then the **effect ID** (as can be read in the node tooltip) *in case the effect node was renamed*. For example ``scene01_B(Col3)_My Blur(Blur1)..tif``  is one of the output files of the scene ``scene01`` , related to the flow going from column B (whose ID is Col3) to the effect node My Blur (whose ID is Blur1).
 
-.. note:: No output will be displayed after the rendering, regardless of **Open Flipbook after Rendering** being activated in Preferences > Preview dialog.
+.. note:: No output will be displayed after the rendering, regardless of **Open Flipbook after Rendering** being activated in Preferences  →  Preview dialog.
 
 .. note:: If you need more control on the way scene elements are rendered, you may consider using Sub-Xsheets and the **Over** effect (see  :ref:`Using Sub-Xsheets <using_sub-xsheets>`  and  :ref:`Over <over>`  ). For example if you want a single output for a set of columns, you may collapse them in a Sub-Xsheet in case of **Flows** type multiple rendering, or connect them to several Over nodes in case of **Terminal Nodes** type multiple rendering.
 
@@ -627,7 +627,7 @@ In this case no image has to be used as background, and the output file format h
 
 .. tip:: **To render animation with alpha channel information:**
 
-    1. Choose Xsheet > **Scene Settings...**.
+    1. Choose Xsheet  →  **Scene Settings...**.
 
     2. Set the alpha channel of the **Camera BG Color** to 0 (i.e. transparent).
 
@@ -646,19 +646,19 @@ If the scene contains some audio files and is rendered in a file format supporti
 
 .. note:: Audio files loaded in Sub-Xsheets will not be included in the output soundtrack (see  :ref:`Using Sub-Xsheets <using_sub-xsheets>`  ).
 
-As soon as the rendering is over, the rendered animation can be automatically displayed in a OpenToonz Flipbook by activating the **Open Flipbook after Rendering** option in the Preferences > Preview dialog; it's also possible to display blank frames after each rendering playback when looping. If a soundtrack is available for the rendered scene, it's also possible to listen to it.
+As soon as the rendering is over, the rendered animation can be automatically displayed in a OpenToonz Flipbook by activating the **Open Flipbook after Rendering** option in the Preferences  →  Preview dialog; it's also possible to display blank frames after each rendering playback when looping. If a soundtrack is available for the rendered scene, it's also possible to listen to it.
 
 When displayed in the Flipbook, the rendering can be checked by using the Flipbook tools (see  :ref:`Using the Flipbook <using_the_flipbook>`  ). 
 
-You can also activate the **Use Default Viewer for Movie Format** option in the Preferences > General dialog, in order to play back the output with its own default viewer, e.g. QuickTime Player for the MOV format.
+You can also activate the **Use Default Viewer for Movie Format** option in the Preferences  →  General dialog, in order to play back the output with its own default viewer, e.g. QuickTime Player for the MOV format.
 
 .. tip:: **To render the currently loaded scene:**
 
-    Choose File > **Render**.
+    Choose File  →  **Render**.
 
 .. tip:: **To display blank frames after each rendering playback when looping:**
 
-    1. Choose File > Preferences > **Preview**.
+    1. Choose File  →  Preferences  →  **Preview**.
 
     2. Do any of the following:
 
@@ -839,7 +839,7 @@ Using Chunks when Rendering Tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 If you are using the OpenToonz render farm, it's possible to divide a task into chunks so that each computer of the farm will render a section of the same render task (see  :ref:`Using the Toonz Farm <using_the_toonz_farm>`  ).
 
-The default value for the chunk size (expressed in number of frames) can be set using the **Render Task Chunk Size** in the Preferences > General pane. If the default value is higher than the duration (in frames) of the submitted scene, the value will be automatically adjusted to be equal to the duration of the scene.
+The default value for the chunk size (expressed in number of frames) can be set using the **Render Task Chunk Size** in the Preferences  →  General pane. If the default value is higher than the duration (in frames) of the submitted scene, the value will be automatically adjusted to be equal to the duration of the scene.
 
 Once a task is submitted, it's possible to change the chunk size by editing the related value in the task properties.
 
@@ -847,7 +847,7 @@ When a task is divided into chunks, each task is represented in the task tree as
 
 Render tasks and sub-tasks will be distributed on the farm, one for each computer, so that several tasks can be executed at the same time (see  :ref:`Using the Toonz Farm <using_the_toonz_farm>`  ). 
 
-If you are not using the OpenToonz render farm, dividing the task into chunks is not only useless, but it slows down the rendering process as well. For this reason it's suggested to use a high **Render Task Chunk Size** value (e.g. 1000) in the Preferences > General pane.
+If you are not using the OpenToonz render farm, dividing the task into chunks is not only useless, but it slows down the rendering process as well. For this reason it's suggested to use a high **Render Task Chunk Size** value (e.g. 1000) in the Preferences  →  General pane.
 
 .. note:: Chunk size is relevant only when animations are rendered as image sequences (for example in TIF or TGA formats).
 

--- a/source/scanning_paper_drawings.rst
+++ b/source/scanning_paper_drawings.rst
@@ -41,7 +41,7 @@ The driver you want to use must be selected according to your scanner before sta
 
 .. tip:: **Windows only - to disable or enable the Windows Image Acquisition (WIA) service:**
 
-    1. Open the Control Panel > Administrative Tools > Services dialog.
+    1. Open the Control Panel  →  Administrative Tools  →  Services dialog.
 
     2. Right-click the Windows Image Acquisition (WIA) service and choose Properties from the menu that opens.
 
@@ -59,13 +59,13 @@ The driver you want to use must be selected according to your scanner before sta
 
 .. tip:: **To define the scanner:**
 
-    1. Choose Scan & Cleanup > Define Scanner.
+    1. Choose Scan & Cleanup  →  Define Scanner.
 
     2. Do one of the following:
 
-    - If your scanner is directly supported, choose Scanner Driver > Internal, and click the OK button.
+    - If your scanner is directly supported, choose Scanner Driver  →  Internal, and click the OK button.
 
-    - If your scanner is not directly supported, be sure that TWAIN drivers are installed, and choose Scanner Driver > TWAIN, and click the OK button: in the dialog that opens, select the TWAIN driver related to your scanner.
+    - If your scanner is not directly supported, be sure that TWAIN drivers are installed, and choose Scanner Driver  →  TWAIN, and click the OK button: in the dialog that opens, select the TWAIN driver related to your scanner.
 
 
 .. _scanning_modes:
@@ -144,9 +144,9 @@ When an animation level is defined, the name and numbers for the drawings of the
 
     1. Do one of the following:
 
-    - Select a cell in the Xsheet where you want to place your animation level to scan and choose File > New Level.
+    - Select a cell in the Xsheet where you want to place your animation level to scan and choose File  →  New Level.
 
-    - Right-click the cell in the Xsheet where you want to place your animation level to scan and choose File > New Level from the menu that opens.
+    - Right-click the cell in the Xsheet where you want to place your animation level to scan and choose File  →  New Level from the menu that opens.
 
 .. note:: If any level is already exposed in the cell column, it will shift down from the cell you selected on.
 
@@ -199,13 +199,13 @@ If you need to scan again an animation level, or a part of it, select the releva
 
     1. In the Xsheet, select the drawings you want to scan. 
 
-    2. Choose Scan & Cleanup > Scan Settings and use the dialog to control scan options. 
+    2. Choose Scan & Cleanup  →  Scan Settings and use the dialog to control scan options. 
 
     3. Do one of the following:
 
-    - If you are using the internal drivers, choose Scan & Cleanup > Scan: the selected drawings will be scanned and automatically saved.
+    - If you are using the internal drivers, choose Scan & Cleanup  →  Scan: the selected drawings will be scanned and automatically saved.
 
-    - If you are using the TWAIN drivers, choose Scan & Cleanup > Scan, and guide the scanning process by using the TWAIN interface that opens: the selected drawings will be scanned and automatically saved.
+    - If you are using the TWAIN drivers, choose Scan & Cleanup  →  Scan, and guide the scanning process by using the TWAIN interface that opens: the selected drawings will be scanned and automatically saved.
 
     4. In case you selected several drawings, do one of the following:
 
@@ -228,7 +228,7 @@ Once defined the cropbox will be used for any scanning performed for the scene.
 
 .. tip:: **To define the scanning cropbox:**
 
-    1. Choose Scan & Cleanup > Set Cropbox: the drawing currently placed in the scanner is scanned and the cropbox is displayed in red. 
+    1. Choose Scan & Cleanup  →  Set Cropbox: the drawing currently placed in the scanner is scanned and the cropbox is displayed in red. 
 
     2. Use the handles along the cropbox to set its size, and click and drag anywhere to change its position.
 
@@ -242,11 +242,11 @@ Once defined the cropbox will be used for any scanning performed for the scene.
 
 .. tip:: **To dismiss the scanning cropbox visualization:**
 
-    Choose Scan & Cleanup > Set Cropbox.
+    Choose Scan & Cleanup  →  Set Cropbox.
 
 .. tip:: **To reset the scanning cropbox:**
 
-    Choose Scan & Cleanup > Reset Cropbox.
+    Choose Scan & Cleanup  →  Reset Cropbox.
 
 
 

--- a/source/setting_up_a_scene.rst
+++ b/source/setting_up_a_scene.rst
@@ -17,7 +17,7 @@ If you want to change the default values you can save current scene settings as 
 
 .. tip:: **To save current scene settings as project default settings:**
 
-    Select File > Save Default Settings: all the settings from the current scene will become the project default.
+    Select File  →  Save Default Settings: all the settings from the current scene will become the project default.
 
 
 .. _choosing_the_working_unit:
@@ -28,11 +28,11 @@ Positions, distances and sizes can be expressed in several units of measure: inc
 
 The field unit is equal to 1/2 inch on the horizontal dimension, and it depends on the A/R set in the field guide information of the Scene Settings... dialog on the vertical dimension (see  :ref:`Using the Viewer <using_the_work_area>`  ). For example if the A/R value is 1.77778, two horizontal fields are equal to an inch, while one vertical field equals to an inch divided by 1.77778.
 
-In the Files > Preferences > Interface dialog you can set the following default units:
+In the Files  →  Preferences  →  Interface dialog you can set the following default units:
 
 - The Unit is used to display all measures in text fields, and applied when moving or changing the size of stage objects.
 
-- The Camera Unit is used to display and define the camera size in the Xsheet > Camera Settings... dialog (see  :ref:`Defining Camera Settings <defining_camera_settings>`  ).
+- The Camera Unit is used to display and define the camera size in the Xsheet  →  Camera Settings... dialog (see  :ref:`Defining Camera Settings <defining_camera_settings>`  ).
 
 You can also express values in an unit different from the default one by entering any of the following units and abbreviations: in, inch, " , ' ' (two apostrophes), cm, mm, fld, field and px, after the input value itself. As soon as the value is entered it's converted in the default unit.
 
@@ -40,7 +40,7 @@ If a value without a specific unit is used, it is supposed to be expressed in th
 
 .. tip:: **To set the default working units:**
 
-    1. Choose File > Preferences > Interface.
+    1. Choose File  →  Preferences  →  Interface.
 
     2. Do one of the following:
 
@@ -61,14 +61,14 @@ The current scene frame rate can be set in the Scene Settings... dialog, and it 
 
 Apart from affecting the playback speed when previewing or rendering a scene, the frame rate also determines the frame count of an audio file when it is imported into the Xsheet (see  :ref:`Creating a Soundtrack <creating_a_soundtrack>`  ).
 
-Even if a scene has been composited with a specific frame rate for a certain output, it is possible to render it out at a different frame rate by using the Stretch from FPS: To: option in the Output Settings > Other Settings dialog (see  :ref:`Choosing the Output Settings <choosing_the_output_settings>`  ).
+Even if a scene has been composited with a specific frame rate for a certain output, it is possible to render it out at a different frame rate by using the Stretch from FPS: To: option in the Output Settings  →  Other Settings dialog (see  :ref:`Choosing the Output Settings <choosing_the_output_settings>`  ).
 
 |stretch_fps_to|
 
 
 .. tip:: **To set the frame rate:**
 
-    1. Choose Xsheet > Scene Settings...
+    1. Choose Xsheet  →  Scene Settings...
 
     2. In the Frame Rate text field set the frame rate value.
 
@@ -83,7 +83,7 @@ The Current Camera Settings dialog, that can be opened from the Xsheet menu, con
 
 More than one camera can be defined for each scene, in order to have different output resolutions, or to shot only a particular area of the scene (see  :ref:`Using the Stage Schematic <using_the_stage_schematic>`  ).
 
-The camera frame size can be expressed in any unit, but will be visualized in the default one chosen in the Preferences > Interface dialog (see  :ref:`Choosing the Working Unit <choosing_the_working_unit>`  ). 
+The camera frame size can be expressed in any unit, but will be visualized in the default one chosen in the Preferences  →  Interface dialog (see  :ref:`Choosing the Working Unit <choosing_the_working_unit>`  ). 
 
 In OpenToonz the Camera is defined by different parameters:
 
@@ -122,11 +122,11 @@ Camera resolutions can also be selected from a list of predefined camera setting
 
 Assigning Memory for the Undo Operations
 ----------------------------------------
-All the operations performed in the software can be undone by using the Edit > Undo command, even to go back for several steps. 
+All the operations performed in the software can be undone by using the Edit  →  Undo command, even to go back for several steps. 
 
 Undo operations require computer memory in order to be performed, and some of them may require more memory than some others, according to their complexity. 
 
-To prevent most of the computer memory to be used by undo operations while you work, a situation that slows down the software performance, it is possible to set a limit for it by specifying the Undo Memory Size (MB) in the Files > Preferences > General dialog. 
+To prevent most of the computer memory to be used by undo operations while you work, a situation that slows down the software performance, it is possible to set a limit for it by specifying the Undo Memory Size (MB) in the Files  →  Preferences  →  General dialog. 
 
 As soon as the limit is reached, the oldest undo operations will be discarded to make room for the new ones.
 
@@ -137,7 +137,7 @@ Optimizing the Memory Usage
 ---------------------------
 When working with Raster images, predominantly being animation levels scanned with OpenToonz or GTS, an extensive usage of computer memory may be required during the cleanup, painting and rendering processes.
 
-After a certain amount of time the computer performance may worsen, as the memory gets fragmented because of the several writing and reading accesses. To prevent this behavior, the Minimize Raster Memory Fragmentation* option can be activated in the Files > Preferences > General dialog. When activated, a section of computer memory is reserved and used only for operations concerning Raster images.
+After a certain amount of time the computer performance may worsen, as the memory gets fragmented because of the several writing and reading accesses. To prevent this behavior, the Minimize Raster Memory Fragmentation* option can be activated in the Files  →  Preferences  →  General dialog. When activated, a section of computer memory is reserved and used only for operations concerning Raster images.
 
 If you are working mainly with vector images, that have been drawn inside OpenToonz, this option should be deactivated, as the reserved memory section would be otherwise unused by the computer.
 

--- a/source/toonzscript.rst
+++ b/source/toonzscript.rst
@@ -12,7 +12,7 @@ The original ToonzScript page with some (rather old) examples is available at th
 
 `ToonzScript page <http://www.toonz.com/htm/support/Script.htm>`_
 
-Scripts can be run using the ``File > Run Script...`` command. Alternatively, commands can be typed and executed directly in the Script Console, which can be opened using the ``File > Open Script Console...`` command.
+Scripts can be run using the ``File  →  Run Script...`` command. Alternatively, commands can be typed and executed directly in the Script Console, which can be opened using the ``File  →  Open Script Console...`` command.
 
 .. note:: When a script is running, the Script Console will open automatically to show the commands contained within the script.
 

--- a/source/using_ffmpeg_with_opentoonz.rst
+++ b/source/using_ffmpeg_with_opentoonz.rst
@@ -42,14 +42,14 @@ Installing
 
 |ffmpeg_extracted_windows|
 
-- Next, start OpenToonz and open the **Preferences** window with ``File > Preferences...``
+- Next, start OpenToonz and open the **Preferences** window with ``File  →  Preferences...``
 - Navigate to the **Import/Export** category; at the top you will see a box with the text **FFmpeg path**.
 - Insert the path to your FFmpeg folder that you created earlier, if you have used the recommended path, this will be **C:\\FFmpeg\\**:
 
 |ffmpeg_path_windows|
 
 - Restart OpenToonz.
-- Open the **Output Settings** window with ``File > Output Settings...``
+- Open the **Output Settings** window with ``File  →  Output Settings...``
 
 | In the **File Settings** subsection, you should now see **mp4** and **webm**.
 
@@ -93,14 +93,14 @@ Installing
 
 |ffmpeg_extracted_mac|
 
-- Next, start OpenToonz and open the **Preferences** window with ``File > Preferences...``
+- Next, start OpenToonz and open the **Preferences** window with ``File  →  Preferences...``
 - Navigate to the **Import/Export** category; at the top you will see a box with the text **FFmpeg path**.
 - Insert the path to your FFmpeg folder that you created earlier, if you have used the recommended path, this will be **/Applications/OpenToonz/FFmpeg**:
 
 |ffmpeg_path_mac|
 
 - Restart OpenToonz.
-- Open the **Output Settings** window with ``File > Output Settings...``
+- Open the **Output Settings** window with ``File  →  Output Settings...``
 
 | In the **File Settings** subsection, you should now see **mp4**, **webm** and **gif**.
 
@@ -123,14 +123,14 @@ Solus: ``# eopkg install ffmpeg``
 
 .. tip:: To make it possible to export files in **mp4**, **webm** or **gif** formats, you need to specify the path to FFmpeg installed on your system, usually it is **/usr/bin/ffmpeg**. Enter command ``which ffmpeg`` in the shell to find out.
 
-- Start OpenToonz and open the **Preferences** window with ``File > Preferences...``
+- Start OpenToonz and open the **Preferences** window with ``File  →  Preferences...``
 - Navigate to the **Import/Export** category; at the top you will see a box with the text **FFmpeg path**.
 - Insert the path **/usr/bin**.
 
 |ffmpeg_path_linux|
 
 - Restart OpenToonz.
-- Open the **Output Settings** window with ``File > Output Settings...``
+- Open the **Output Settings** window with ``File  →  Output Settings...``
 
 | In the **File Settings** subsection, you should now see **mp4**, **webm** and **gif**.
 

--- a/source/using_the_toonz_farm.rst
+++ b/source/using_the_toonz_farm.rst
@@ -56,7 +56,7 @@ Since the Toonz Farm Controller needs to access the FARMROOT folder, typically s
 
 .. tip:: **To run the Toonz Farm Controller as a user with the proper rights:**
 
-    1. Choose Control Panel > Administrative Tools > Services, and right-click the Toonz Farm Controller service to open the Properties panel.
+    1. Choose Control Panel  →  Administrative Tools  →  Services, and right-click the Toonz Farm Controller service to open the Properties panel.
 
     2. Select the Log On page, check the This Account option.
 
@@ -77,7 +77,7 @@ Since the Toonz Farm Server, for rendering purposes, needs to access one or more
 
 .. tip:: **To run the Toonz Farm Controller as an user with the proper rights:**
 
-    1. Choose Control Panel > Administrative Tools > Services, and right-click the Toonz Farm Server service to open the Properties panel.
+    1. Choose Control Panel  →  Administrative Tools  →  Services, and right-click the Toonz Farm Server service to open the Properties panel.
 
     2. Select the Log On page, check the This Account option.
 

--- a/source/using_the_version_control.rst
+++ b/source/using_the_version_control.rst
@@ -189,7 +189,7 @@ At this point the repository will be displayed in the OpenToonz browser, and you
 
 .. tip:: **To initialize the version control system:**
 
-    1. In OpenToonz open the Preferences > Version Control dialog and activate the **Enable Version Control** option.
+    1. In OpenToonz open the Preferences  →  Version Control dialog and activate the **Enable Version Control** option.
 
      .. note:: If the version control is not correctly installed or the configuration file is not correctly defined, activating the option will prompt a warning message.
 
@@ -214,7 +214,7 @@ When a folder is selected in the folder tree *a refresh operation occurs automat
 
 .. tip:: **To disable the automatic refresh for folder content:**
 
-    1. Choose File > Preferences > Version Control.
+    1. Choose File  →  Preferences  →  Version Control.
 
     2. Deactivate the **Automatically Refresh Folder Contents** option.
 

--- a/source/working_in_xsheet.rst
+++ b/source/working_in_xsheet.rst
@@ -58,9 +58,9 @@ All the elements you need for a scene can be retrieved by using a file browser.
 
 You can either use the standard OpenToonz file browser to drag and drop levels or folders to the Xsheet/Timeline or the Scene Cast window, or use the Load Level... and Load Folder... commands from the File menu. In both cases you can perform a multiple selection to load several levels or folders at the same time, that will be exposed each in a separate column; if you use the Load Level... command, when loading an animation level you can also specify the frame range to load. When you use the Load Folder... command all the files contained in the folder (if supported) are loaded into the Xsheet/Timeline.
 
-.. note:: When a level is loaded, OpenToonz checks if its syntax matches one of the level formats specified into Preferences > Loading > **Level Settings by File Format**. In this case the Level Settings specified will be applied. It is possible to add as many formats as you want, defining them by using a Regular Expression. This way, different settings can be automatically applied to different kind of levels.
+.. note:: When a level is loaded, OpenToonz checks if its syntax matches one of the level formats specified into Preferences  →  Loading  →  **Level Settings by File Format**. In this case the Level Settings specified will be applied. It is possible to add as many formats as you want, defining them by using a Regular Expression. This way, different settings can be automatically applied to different kind of levels.
 
-.. note:: It is possible to **Ignore Alpha Channel on Levels in Column 1** by activating the option in Preferences > Xsheet.
+.. note:: It is possible to **Ignore Alpha Channel on Levels in Column 1** by activating the option in Preferences  →  Xsheet.
 
 In the file tree available on the left there are the following main items:
 
@@ -84,7 +84,7 @@ In the file tree available on the left there are the following main items:
 
 You can open folders and sub-folders in order to retrieve files that are displayed in the area on the right. The current location path is displayed at the top of the browser; existing folders can be renamed and new folders can be created. Files can be displayed as icons or as a list, displaying additional informations that can be also used to sort them.
 
-.. note:: The way file icons are generated in the OpenToonz browser depends on the images resolution and on the **Icon Size** option set for the Level Strip frames in the Preferences > Interface dialog (see  :ref:`Using the Level Strip <using_the_level_strip>`  ).
+.. note:: The way file icons are generated in the OpenToonz browser depends on the images resolution and on the **Icon Size** option set for the Level Strip frames in the Preferences  →  Interface dialog (see  :ref:`Using the Level Strip <using_the_level_strip>`  ).
 
 
 .. _loading_levels:
@@ -112,7 +112,7 @@ From the browser, you can **View** images and clips you are going to load as lev
 
 OpenToonz scenes (TNZ files) can be loaded as part of another scene as well, in such a case they are loaded as Sub-Xsheets (see  :ref:`Loading a Scene as a Sub-Xsheet <loading_a_scene_as_a_sub-xsheet>`  ).
 
-When you load levels using the standard OpenToonz file browser, you can set whether to automatically expose them in the Xsheet/Timeline or not, by setting the **Expose Loaded Levels in Xsheet** option in the Preferences > Loading dialog. If activated, each level will be placed in a different column/layer, starting from the first empty one. If deactivated, the loaded levels will be stored in the Scene Cast, from where they can be selectively exposed in Xsheet columns or Timeline layers (see  :ref:`Using the Scene Cast <using_the_scene_cast>`  ).
+When you load levels using the standard OpenToonz file browser, you can set whether to automatically expose them in the Xsheet/Timeline or not, by setting the **Expose Loaded Levels in Xsheet** option in the Preferences  →  Loading dialog. If activated, each level will be placed in a different column/layer, starting from the first empty one. If deactivated, the loaded levels will be stored in the Scene Cast, from where they can be selectively exposed in Xsheet columns or Timeline layers (see  :ref:`Using the Scene Cast <using_the_scene_cast>`  ).
 
 If you are loading one or several files located outside the default current project folders, you are prompted whether to **Import** them to the project database or to **Load** them from where they are. In the former case files will be copied to the appropriate project folder (PLI, TLV levels and their palettes in the *+drawings* folder; raster images, video clips and audio files in the *+extras* folder; standalone palettes in the *+palettes* folder, etc.) and loaded with a relative path from this new location (see  :ref:`Managing Projects <managing_projects>`  ); in the latter case they will be loaded using an absolute path to their original location.
 
@@ -160,7 +160,7 @@ If any of the files you want to import has the same name of a file already exist
 
     2. Do one of the following:
 
-    - Choose File > Load Level.
+    - Choose File  →  Load Level.
 
     - Right-click in the Xsheet/Timeline cell and choose Load Level from the menu that opens.
 
@@ -196,11 +196,11 @@ If any of the files you want to import has the same name of a file already exist
 
     .. note:: Folders can also be loaded by dragging and dropping them from the Windows Explorer or macOS Finder to the scene cast, Xsheet/Timeline, or Viewer.
 
-.. note:: When a level is loaded, OpenToonz checks if its syntax matches one of the level formats specified in Preferences > Loading > **Level Settings by File Format**. In this case the Level Settings specified when the corresponding **Edit** button is opened will be applied. It is possible to add as many file formats as you want, defining them by using a Regular Expression. This way, different settings can be automatically applied to different kind of levels.
+.. note:: When a level is loaded, OpenToonz checks if its syntax matches one of the level formats specified in Preferences  →  Loading  →  **Level Settings by File Format**. In this case the Level Settings specified when the corresponding **Edit** button is opened will be applied. It is possible to add as many file formats as you want, defining them by using a Regular Expression. This way, different settings can be automatically applied to different kind of levels.
 
 .. tip:: **To load back a recently loaded level:**
 
-    Choose File > Open Recent Level File, then select the level you want to load from the available submenu.
+    Choose File  →  Open Recent Level File, then select the level you want to load from the available submenu.
 
 .. tip:: **To make a multiple selection in the file browser:**
 
@@ -220,13 +220,13 @@ If any of the files you want to import has the same name of a file already exist
 
     - In the OpenToonz browser or in the Xsheet right-click the level you want to view and choose View from the menu that opens.
 
-    - Choose Windows > Flipbook and drag and drop in the window the file you want to view.
+    - Choose Windows  →  Flipbook and drag and drop in the window the file you want to view.
 
   .. note:: By opening several Flipbook windows you can view several levels at the same time.
 
 .. tip:: **To set the default shrink factor and step for the file viewer:**
 
-    1. Choose File > Preferences > Interface.
+    1. Choose File  →  Preferences  →  Interface.
 
     2. Set the default **Viewer Shrink** and **Step** values.
 
@@ -597,7 +597,7 @@ You can create new folders and sub-folders where animation levels can be arrange
 
     Do one of the following:
 
-    - Choose Level > **Expose in Xsheet**.
+    - Choose Level  →  **Expose in Xsheet**.
 
     - Right-click the selection in the Scene Cast and choose **Expose in Xsheet** from the menu that opens. In case of a multiple level selection, each level will be placed in a different column/layer, starting from the first empty one.
 
@@ -607,7 +607,7 @@ You can create new folders and sub-folders where animation levels can be arrange
 
     Do one of the following:
 
-    - Select it in the Scene Cast and choose Level > **Display in Level Strip**.
+    - Select it in the Scene Cast and choose Level  →  **Display in Level Strip**.
 
     - Right-click it in the Scene Cast and choose **Display in Level Strip** from the menu that opens.
 
@@ -621,7 +621,7 @@ You can create new folders and sub-folders where animation levels can be arrange
 
     Do one of the following:
 
-    - Choose Level > **Remove All Unused Levels**.
+    - Choose Level  →  **Remove All Unused Levels**.
 
     - Right-click in the Scene Cast and choose **Remove All Unused Levels** from the menu that opens.
 
@@ -640,7 +640,7 @@ When an animation level is displayed in the Level Strip, you can select the spec
 
     - Select any level drawing exposed in the Xsheet/Timeline.
 
-    - Select it in the Scene Cast and choose Level > **Display in Level Strip**.
+    - Select it in the Scene Cast and choose Level  →  **Display in Level Strip**.
 
     - Right-click it the Scene Cast and choose **Display in Level Strip** from the menu that opens.
 
@@ -689,7 +689,7 @@ The original level is preserved in the Scene Cast from where it can be retrieved
 
     2. Do one of the following:
 
-    - Choose Level > **Replace Level...**.
+    - Choose Level  →  **Replace Level...**.
 
     - Right-click the selection and choose one of the options in the **Replace Level** submenu, from the menu that opens.
 
@@ -729,7 +729,7 @@ Once a level is exposed, its properties (path, DPI, subsampling, etc.), can be c
 
     - **Add Antialiasing** gives the user the possibility to add antialiasing to the level. The antialiasing value has to be specified in the **Antialias Softness** field, which can range from 0 to 100. This option is available on Toonz Raster and Raster levels.
 
-    - **Subsampling** sets the simplifying factor to be applied to animation levels, clips and images when displayed in the work area in order to have a faster visualization and playback; for example if it is 2, one pixel every two pixels is displayed. The default values are defined in Xsheet > Scene Settings dialog, where values for raster (Image) and toonz raster (TLV) level subsampling can be defined.
+    - **Subsampling** sets the simplifying factor to be applied to animation levels, clips and images when displayed in the work area in order to have a faster visualization and playback; for example if it is 2, one pixel every two pixels is displayed. The default values are defined in Xsheet  →  Scene Settings dialog, where values for raster (Image) and toonz raster (TLV) level subsampling can be defined.
 
       .. note:: The subsampling factor can also be applied to all the animation levels exposed in selected columns by right-clicking the header of any selected column and choosing one of the **Subsampling** commands from the menu that opens.
 
@@ -737,7 +737,7 @@ Once a level is exposed, its properties (path, DPI, subsampling, etc.), can be c
 
     Do one of the following:
 
-    - Select a level in the Xsheet/Timeline and choose Level > **Level Settings...**.
+    - Select a level in the Xsheet/Timeline and choose Level  →  **Level Settings...**.
 
     - Right-click a level in the Xsheet/Timeline and choose **Level Setting...** from the menu that opens.
 
@@ -763,13 +763,13 @@ The Xsheet Toolbar pane can be toggled depending on user preferences.
 
     - Right click on any column/layer header and choose **Toggle Xsheet Toolbar** from the menu that opens.
 
-    - Activate the File > Preferences > Xsheet > **Show Toolbar in the Xsheet** option.
+    - Activate the File  →  Preferences  →  Xsheet  →  **Show Toolbar in the Xsheet** option.
 
     .. note:: When the Xsheet Toolbar is shown, it's also possible to activate the **Expand Function Editor Header to Match Xsheet Toolbar Height** option to correctly match the *frame* rows in both editors, when put side by side.
 
 .. tip:: **To customize the Xsheet Toolbar buttons:**
 
-    1. Choose Windows > Command Bar to open the Command Bar.
+    1. Choose Windows  →  Command Bar to open the Command Bar.
 
     2. Right click on it and select **Customize Xsheet Toolbar** from the menu that opens. The Customize Xsheet Toolbar window will open.
 
@@ -794,7 +794,7 @@ When levels are exposed in the Xsheet they are placed in columns (layers, in the
 
 |timeline|
 
-The Xsheet is divided into sections divided by horizontal markers (vertical, in case of the Timeline), whose interval can be customized; at each marker the name of the levels exposed can be displayed, when the option **Display Level Name on Each Marker** is active in the Preferences > Interface dialog.
+The Xsheet is divided into sections divided by horizontal markers (vertical, in case of the Timeline), whose interval can be customized; at each marker the name of the levels exposed can be displayed, when the option **Display Level Name on Each Marker** is active in the Preferences  →  Interface dialog.
 
 Column/layer cells may have different colors according to the type of level they contain. Toonz Vector levels are displayed in dark yellow; Toonz Raster levels in green; Raster levels in light blue; Sub-Xsheets in violet (see  :ref:`Using Sub-Xsheets <using_sub-xsheets>`  ); Effect levels generated by OpenToonz in brown (see  :ref:`Using the FX Schematic <using_the_fx_schematic>`  ); Audio levels in pale green (see  :ref:`Creating a Soundtrack <creating_a_soundtrack>`  ); and Note levels in grey.
 
@@ -812,17 +812,17 @@ Each column/layer header contains information about its content. These are:
 
     - **Additional settings** button (|additional_settings|) allowing you to set an **Opacity** value or a **Color Filter** to the column/layer content, when displayed in the viewer. When a column/layer has a partial opacity, its **Camera stand toggle** changes to a faded icon to indicate it.
 
-      .. note:: Optionally you can make these additional properties also take effect at render time by activating the **Enable Column Color Filter and Transparency for Rendering** option in the Xsheet > Scene Settings... dialog.
+      .. note:: Optionally you can make these additional properties also take effect at render time by activating the **Enable Column Color Filter and Transparency for Rendering** option in the Xsheet  →  Scene Settings... dialog.
 
     - **Preview icon** of the first drawing or image exposed in the column/layer.
 
-      .. note:: The icons on the Xsheet column headers can either be displayed at once when the scene is opened, or on demand by clicking on the column header, according to the **Column Icon** option available in Preferences > Xsheet.
+      .. note:: The icons on the Xsheet column headers can either be displayed at once when the scene is opened, or on demand by clicking on the column header, according to the **Column Icon** option available in Preferences  →  Xsheet.
 
     - **Parent** information, is an area where the object (by default the Table) and center (by default center B) to which each column/layer is parented is displayed (see  :ref:`Linking Objects <linking_objects>`  ). Currently this is not shown in the Timeline header.
 
 In the Xsheet, the column on the far left displays the frame number, with the cursor indicating the current frame. The cursor can be used to set the current frame and allows you to activate the onion skin mode to better check the animation (see  :ref:`Using Onion Skin <using_onion_skin>`  ). In the Timeline, the same controls are placed in the time ruler at the top of the Timeline, having an equivalent functionality.
 
-.. note:: When the animation is played back, the Xsheet/Timeline scrolls according to the current frame cursor position, in order to display the current frame. To disable the scrolling deactivate the **Xsheet Autopan during Playback** option available in the Preferences > Xsheet dialog.
+.. note:: When the animation is played back, the Xsheet/Timeline scrolls according to the current frame cursor position, in order to display the current frame. To disable the scrolling deactivate the **Xsheet Autopan during Playback** option available in the Preferences  →  Xsheet dialog.
 
 Above the frame number column, there are buttons for creating and navigating Memos that can be posted in the Xsheet/Timeline (see  :ref:`Using Memos <using_memos>`  ).
 
@@ -852,7 +852,7 @@ Columns/layers you want to hide in the Xsheet/Timeline can be folded in order to
 
 .. tip:: **To set the marker interval:**
 
-    1. Choose Xsheet > Scene Settings...
+    1. Choose Xsheet  →  Scene Settings...
 
     2. In the dialog that opens use the **Marker Interval** to set the frame interval between two markers, and the **Start Frame** to set at which frame the first marker has to be displayed. 
 
@@ -922,7 +922,7 @@ Columns/layers you want to hide in the Xsheet/Timeline can be folded in order to
 
     Click the triangle icon (|additional_settings|) on the column/layer header, and set the **Filter** parameter to one of its predefined colors.
 
-.. note:: You can make Opacity and Color Filter take effect at render time by activating the **Enable Column Color Filter and Transparency for Rendering** option in the Xsheet > Scene Settings... dialog.
+.. note:: You can make Opacity and Color Filter take effect at render time by activating the **Enable Column Color Filter and Transparency for Rendering** option in the Xsheet  →  Scene Settings... dialog.
 
 .. tip:: **To fold columns/layers:**
 
@@ -1047,7 +1047,7 @@ Selected cells can also be dragged to a new position in the Xsheet/Timeline, in 
 
 .. tip:: **To drag a cell selection moving along the column/layer data:**
 
-    1. Choose File > Preferences > Xsheet.
+    1. Choose File  →  Preferences  →  Xsheet.
 
     2. Set the Cell-dragging Behaviour option to **Cells and Column Data**.
 
@@ -1117,7 +1117,7 @@ Options are the following:
 
     2. Do one of the following:
 
-    - Choose Cells > **Time Stretch...**.
+    - Choose Cells  →  **Time Stretch...**.
 
     - Right-click the selection and choose **Time Stretch...** from the menu that opens.
 
@@ -1140,13 +1140,13 @@ When a frame is removed, the current frame cells are deleted, and the following 
 
     1. Select the frame before which you want to insert a new frame.
 
-    2. Choose Xsheet > **Insert Frame**.
+    2. Choose Xsheet  →  **Insert Frame**.
 
 .. tip:: **To remove a frame:**
 
     1. Select the frame you want to delete.
 
-    2. Choose Xsheet > **Remove Frame**.
+    2. Choose Xsheet  →  **Remove Frame**.
 
 
 .. _using_sub-xsheets:
@@ -1192,7 +1192,7 @@ When copying Sub-Xsheet columns/layers and cells, their copies refer always to t
 
     2. Do one of the following:
 
-    - Choose Xsheet > **Collapse**.
+    - Choose Xsheet  →  **Collapse**.
 
     - Click the **Collapse** button in the Xsheet Toolbar. 
     
@@ -1204,7 +1204,7 @@ When copying Sub-Xsheet columns/layers and cells, their copies refer always to t
 
     Do one of the following
 
-    - Choose Xsheet > **Close Sub-Xsheet**.
+    - Choose Xsheet  →  **Close Sub-Xsheet**.
 
     - Click the **Close Sub-Xsheet** button in the Xsheet Toolbar. 
 
@@ -1214,7 +1214,7 @@ When copying Sub-Xsheet columns/layers and cells, their copies refer always to t
 
     2. Do one of the following:
 
-    - Choose Xsheet > **Open Sub-Xsheet**.
+    - Choose Xsheet  →  **Open Sub-Xsheet**.
 
     - Click the **Open Sub-Xsheet** button in the Xsheet/Timeline Toolbar. 
 
@@ -1226,7 +1226,7 @@ When copying Sub-Xsheet columns/layers and cells, their copies refer always to t
 
     2. Do one of the following:
 
-    - Choose Xsheet > **Clone Sub-Xsheet**.
+    - Choose Xsheet  →  **Clone Sub-Xsheet**.
 
     - Right-click the column header and choose **Clone Sub-Xsheet** from the menu that opens.
 
@@ -1234,7 +1234,7 @@ When copying Sub-Xsheet columns/layers and cells, their copies refer always to t
 
     Do one of the following
 
-    - Choose Xsheet > **Toggle Edit in Place**.
+    - Choose Xsheet  →  **Toggle Edit in Place**.
     
     - Click the **Toggle Edit in Place** button in the Xsheet/Timeline Toolbar. 
 
@@ -1244,7 +1244,7 @@ When copying Sub-Xsheet columns/layers and cells, their copies refer always to t
 
     2. Do one of the following:
 
-    - Choose Xsheet > **Resequence**.
+    - Choose Xsheet  →  **Resequence**.
 
     - Right-click the column header and choose **Resequence** from the menu that opens.
 
@@ -1259,7 +1259,7 @@ Every time a scene is loaded as a Sub-Xsheet, its contents are imported into the
 
 This allows you to create a library of basic animations that can be loaded and edited in other Xsheets/Timelines to create more complex animations without affecting the original files or drawings. Even when the same Sub-Xsheet is loaded twice, it is handled as if two different Sub-Xsheets were loaded, whose contents and levels can be edited separately.
 
-To keep the database well-ordered you can also activate the **Create Sub-folder when Importing Sub-Xsheet** option in the Preferences > Loading dialog, that will automatically create, in the project default folder, a folder named as the Sub-Xsheet you are importing where the levels from the Sub-Xsheet will be copied. 
+To keep the database well-ordered you can also activate the **Create Sub-folder when Importing Sub-Xsheet** option in the Preferences  →  Loading dialog, that will automatically create, in the project default folder, a folder named as the Sub-Xsheet you are importing where the levels from the Sub-Xsheet will be copied. 
 
 Once a Sub-Xsheet is loaded, its levels are available in the Scene Cast in a sub-folder named as the scene you loaded.
 
@@ -1271,9 +1271,9 @@ If the camera settings of the scene you are loading as a Sub-Xsheet are differen
 
     Do one of the following:
 
-    - Choose File > **Load Level** and use the browser to load a TNZ file.
+    - Choose File  →  **Load Level** and use the browser to load a TNZ file.
 
-    - Choose File > **Load As Sub-Xsheet** and use the browser to load a TNZ file.
+    - Choose File  →  **Load As Sub-Xsheet** and use the browser to load a TNZ file.
 
     - Use the OpenToonz standard browser to drag the scene icon to the Scene Cast pane, the Xsheet/Timeline or the viewer.
 
@@ -1298,7 +1298,7 @@ Sub-Xsheets can be exploded to automatically bring their content into the Xsheet
 
     2. Do one of the following:
 
-    - Choose Xsheet > **Explode**.
+    - Choose Xsheet  →  **Explode**.
 
     - Right-click the Sub-Xsheet column header and choose **Explode** from the menu that opens.
 
@@ -1317,14 +1317,14 @@ The Sub-Xsheet content will be saved according to the current project settings f
 
     1. Open the Sub-Xsheet you want to save, so that its contents are displayed in the Xsheet/Timeline.
 
-    2. Choose Xsheet > **Save Sub-Xsheet As...** and use the browser to save the scene file (see  :ref:`Saving and Loading Scenes <saving_and_loading_scenes>`  ).
+    2. Choose Xsheet  →  **Save Sub-Xsheet As...** and use the browser to save the scene file (see  :ref:`Saving and Loading Scenes <saving_and_loading_scenes>`  ).
 
 
 .. _creating_a_soundtrack:
 
 Creating a Soundtrack
 ---------------------
-Audio clips can be loaded and edited in order to create a soundtrack for the scene; natively supported file formats are non-compressed ``WAV`` and ``AIFF``  files at 8 and 16 bit. If FFmpeg is installed and configured in Preferences > Import/Export dialog, ``MP3`` audio files can be loaded too. There is no limit to the number of audio clips that can be loaded in a scene.
+Audio clips can be loaded and edited in order to create a soundtrack for the scene; natively supported file formats are non-compressed ``WAV`` and ``AIFF``  files at 8 and 16 bit. If FFmpeg is installed and configured in Preferences  →  Import/Export dialog, ``MP3`` audio files can be loaded too. There is no limit to the number of audio clips that can be loaded in a scene.
 
 To load an audio clip you can use the Browser room; if an audio clip is imported, it is saved in the *+extras* folder (see  :ref:`Using the File Browser <using_the_file_browser>`  ). Loaded audio clips are also stored in the Audio folder of the Scene Cast.
 
@@ -1354,7 +1354,7 @@ When a scene is rendered in a file format supporting audio, (MP4, MOV, WebM or A
 
 .. note:: Audio clips loaded in Sub-Xsheets will not be included in the output soundtrack (see  :ref:`Using Sub-Xsheets <using_sub-xsheets>`  ).
 
-.. note:: As the soundtrack cannot be played back when viewing files in the OpenToonz flipbook, you can activate the **Use Default Viewer for Movie Formats** option in the Preferences > General dialog, in order to view files with their own default viewer, e.g. QuickTime for the MOV format, thus playing back the soundtrack as well.
+.. note:: As the soundtrack cannot be played back when viewing files in the OpenToonz flipbook, you can activate the **Use Default Viewer for Movie Formats** option in the Preferences  →  General dialog, in order to view files with their own default viewer, e.g. QuickTime for the MOV format, thus playing back the soundtrack as well.
 
 .. tip:: **To play the contents of an audio column/layer back:**
 
@@ -1527,11 +1527,11 @@ While Magpie takes care of the audio file analysis and phoneme recognition, impo
 
     1. Copy the file ``export-toonz.lua``  available in ``OpenToonz stuff\config``  folder into the ``C:\Program Files (x86)\Third Wish Software & Animation\Magpie Pro\Scripts\Export``  folder.
 
-    2. In Magpie choose File > Export and choose Toonz among the 2D software list to export the TLS file.
+    2. In Magpie choose File  →  Export and choose Toonz among the 2D software list to export the TLS file.
 
 .. tip:: **To import a Magpie file:**
 
-    1. Choose File > **Import Magpie File...**.
+    1. Choose File  →  **Import Magpie File...**.
 
     2. In the browser that opens retrieve the TLS file you exported from Magpie and click the **Load** button.
 
@@ -1641,25 +1641,25 @@ Scene files can be saved and loaded as TNZ files using the related menu commands
 
 When you use the **Save As...** command, if the *$scenepath* is used in the default folders definition, all the material used in the scenes and located in project default folders will be duplicated in folders related to the new scene (see  :ref:`Using the $scenepath Variable in Folder Definition <using_the_$scenepath_variable_in_folder_definition>`  ).
 
-An option **Save Automatically** allows to save the scene every given number of minutes, and is available in the Preferences > General dialog. If the option is activated, during the saving operation a message is displayed to notify the process.
+An option **Save Automatically** allows to save the scene every given number of minutes, and is available in the Preferences  →  General dialog. If the option is activated, during the saving operation a message is displayed to notify the process.
 
 .. note:: An asterisk to the right of the scene name in the Viewer and Xsheet/Timeline title bars, denotes that there are unsaved changes for the current scene.
 
 .. tip:: **To work on a new scene:**
 
-    Choose File > **New Scene**.
+    Choose File  →  **New Scene**.
 
 .. tip:: **To save a scene and all its related levels:**
 
-    Choose File > **Save All**.
+    Choose File  →  **Save All**.
 
 .. tip:: **To save a scene:**
 
-    Choose File > **Save Scene**.
+    Choose File  →  **Save Scene**.
 
 .. tip:: **To save the current scene with a different name:**
 
-    1. Choose File > **Save Scene As...**
+    1. Choose File  →  **Save Scene As...**
 
     2. In the browser that opens select the current project *+scenes* folder, or any of its sub-folders, where you want to save the scene.
 
@@ -1667,7 +1667,7 @@ An option **Save Automatically** allows to save the scene every given number of 
 
 .. tip:: **To load a scene from the Load Scene browser:**
 
-    1. Choose File > **Load Scene...**
+    1. Choose File  →  **Load Scene...**
 
     2. In the browser that opens retrieve, in the *+scenes* folder of the current project or any of its sub-folders, the scene you want to load and click the **Load** button.
 
@@ -1683,15 +1683,15 @@ An option **Save Automatically** allows to save the scene every given number of 
 
 .. tip:: **To load back a recently loaded scene:**
 
-    Choose File > **Open Recent Scene File**, then select the scene you want to load from the available submenu.
+    Choose File  →  **Open Recent Scene File**, then select the scene you want to load from the available submenu.
 
 .. tip:: **To revert the current scene to the last saved version:**
 
-    Choose File > **Revert Scene**.
+    Choose File  →  **Revert Scene**.
 
 .. tip:: **To automatically save a scene every given number of minutes:**
 
-    1. Choose File > Preferences > General.
+    1. Choose File  →  Preferences  →  General.
 
     2. Activate the **Save Automatically** option and enter the number of minutes that have to pass between each saving operation.
    


### PR DESCRIPTION
Replacement ` > ` to ` → `. IMHO, that looks better.
![Screenshot_20190626_120954](https://user-images.githubusercontent.com/34054456/60150508-a1e96300-980b-11e9-9402-564d46145ca8.png)
